### PR TITLE
Re-wrote the ion chamber scaler counts-to-volts calculation.

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -101,7 +101,10 @@ def sim_registry(monkeypatch):
 def sim_ion_chamber(sim_registry):
     FakeIonChamber = make_fake_device(IonChamber)
     ion_chamber = FakeIonChamber(
-        prefix="scaler_ioc", name="I00", labels={"ion_chambers"}, ch_num=2
+        prefix="scaler_ioc",
+        name="I00",
+        labels={"ion_chambers"},
+        ch_num=2,
     )
     # Set metadata
     preamp = ion_chamber.preamp

--- a/src/haven/iconfig_testing.toml
+++ b/src/haven/iconfig_testing.toml
@@ -78,6 +78,8 @@ preamp_channels = [3]
 # Produces PVs e.g. 25idc:LJT7Voltmeter_0:Ai1
 voltmeter_prefix = "255idc:LabjackT7_0:"
 voltmeter_channels = [1]
+# From V2F100: Fmax / Vmax
+counts_per_volt_second = 10e6
 
 # Motors
 # ======

--- a/src/haven/motor_position.py
+++ b/src/haven/motor_position.py
@@ -26,7 +26,7 @@ __all__ = [
 class MotorAxis(BaseModel):
     name: str
     readback: float
-    offset: float = None
+    offset: Optional[float] = None
 
     def as_dict(self):
         return {"name": self.name, "readback": self.readback, "offset": self.offset}


### PR DESCRIPTION
Previously, we assumed the clock frequency for channel 1 was the same as the max frequency of the V-to-F source (e.g. V2F100), and that the max V-to-F is 10V. This change removes that assumption, and the max source frequency and max voltage of the V-to-F are now an iconfig parameter (counts_per_volt_second).