### PR TITLE
UX improvements for queueserver controls in Firefly

### DIFF
--- a/src/firefly/application.py
+++ b/src/firefly/application.py
@@ -15,8 +15,8 @@ from pydm.utilities.stylesheet import apply_stylesheet
 from PyQt5.QtWidgets import QStyleFactory
 from qtpy import QtCore, QtWidgets
 from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QAction
 from qtpy.QtGui import QKeySequence
+from qtpy.QtWidgets import QAction
 
 from haven import load_config
 from haven import load_instrument as load_haven_instrument
@@ -130,7 +130,9 @@ class FireflyApplication(PyDMApplication):
             self._queue_thread.wait(msecs=5000)
             assert not self._queue_thread.isRunning()
 
-    def _setup_window_action(self, action_name: str, text: str, slot: QtCore.Slot, shortcut=None, icon=None):
+    def _setup_window_action(
+        self, action_name: str, text: str, slot: QtCore.Slot, shortcut=None, icon=None
+    ):
         action = QtWidgets.QAction(self)
         action.setObjectName(action_name)
         action.setText(text)
@@ -355,20 +357,49 @@ class FireflyApplication(PyDMApplication):
         # Navbar actions for controlling the run engine
         actions = [
             # (action_name, text, icon, shortcut, tooltip)
-            ("pause_runengine_action", "Pause", "fa5s.stopwatch", None,
-             "Pause the current plan at the next checkpoint."),
-            ("pause_runengine_now_action", "Pause Now", "fa5s.pause", "Ctrl+C",
-             "Pause the run engine now."),
-            ("resume_runengine_action", "Resume", "fa5s.play", None,
-             "Resume the previously-paused run engine at the last checkpoint."),
-            ("stop_runengine_action", "Stop", "fa5s.stop", None,
-             "End the current plan, marking as success."),
-            ("abort_runengine_action", "Abort", "fa5s.eject", None,
-             "End the current plan, marking as failure."),
-            ("halt_runengine_action", "Halt", "fa5s.ban", None,
-             "End the current plan immediately, do not clean up."),
-            ("start_queue_action", "Start", "fa5s.play", None,
-             "Start the queue."),
+            (
+                "pause_runengine_action",
+                "Pause",
+                "fa5s.stopwatch",
+                None,
+                "Pause the current plan at the next checkpoint.",
+            ),
+            (
+                "pause_runengine_now_action",
+                "Pause Now",
+                "fa5s.pause",
+                "Ctrl+C",
+                "Pause the run engine now.",
+            ),
+            (
+                "resume_runengine_action",
+                "Resume",
+                "fa5s.play",
+                None,
+                "Resume the previously-paused run engine at the last checkpoint.",
+            ),
+            (
+                "stop_runengine_action",
+                "Stop",
+                "fa5s.stop",
+                None,
+                "End the current plan, marking as success.",
+            ),
+            (
+                "abort_runengine_action",
+                "Abort",
+                "fa5s.eject",
+                None,
+                "End the current plan, marking as failure.",
+            ),
+            (
+                "halt_runengine_action",
+                "Halt",
+                "fa5s.ban",
+                None,
+                "End the current plan immediately, do not clean up.",
+            ),
+            ("start_queue_action", "Start", "fa5s.play", None, "Start the queue."),
         ]
         self.queue_action_group = QtWidgets.QActionGroup(self)
         for name, text, icon_name, shortcut, tooltip in actions:
@@ -683,9 +714,7 @@ class FireflyApplication(PyDMApplication):
 
     def show_status_window(self, stylesheet_path=None):
         """Instantiate a new main window for this application."""
-        self.show_window(
-            PlanMainWindow, ui_dir / "status.py", name="beamline_status"
-        )
+        self.show_window(PlanMainWindow, ui_dir / "status.py", name="beamline_status")
 
     @QtCore.Slot()
     def show_run_browser_window(self):

--- a/src/firefly/application.py
+++ b/src/firefly/application.py
@@ -265,13 +265,13 @@ class FireflyApplication(PyDMApplication):
         )
         # Actions for executing plans
         plans = [
-            # (plan_name, text, display file, shortcut)
-            ("count", "&Count", "count.py", "Ctrl+Shift+C"),
-            ("line_scan", "&Line scan", "line_scan.py", "Ctrl+Shift+L"),
-            ("xafs_scan", "&XAFS Scan", "xafs_scan.py", "Ctrl+Shift+X"),
+            # (plan_name, text, display file, shortcut, icon)
+            ("count", "&Count", "count.py", "Ctrl+Shift+C", "mdi.counter"),
+            ("line_scan", "&Line scan", "line_scan.py", "Ctrl+Shift+L", None),
+            ("xafs_scan", "&XAFS Scan", "xafs_scan.py", "Ctrl+Shift+X", None),
         ]
         self.plan_actions = []
-        for plan_name, text, display_file, shortcut in plans:
+        for plan_name, text, display_file, shortcut, icon in plans:
             slot = partial(
                 self.show_plan_window, name=plan_name, display_file=display_file
             )
@@ -283,6 +283,8 @@ class FireflyApplication(PyDMApplication):
             action.triggered.connect(slot)
             if shortcut is not None:
                 action.setShortcut(QKeySequence(shortcut))
+            if icon is not None:
+                action.setIcon(qta.icon(icon))
             self.plan_actions.append(action)
         # Action for showing the run browser window
         self._setup_window_action(
@@ -533,8 +535,14 @@ class FireflyApplication(PyDMApplication):
           queueserver API. Used for testing.
 
         """
+        # Load the API for controlling the queueserver.
         if api is None:
-            api = queueserver_api()
+            try:
+                api = queueserver_api()
+            except InvalidConfiguration:
+                log.error("Could not load queueserver API "
+                          "configuration from iconfig.toml file.")
+                return
         # Create the client object
         if client is None:
             client = QueueClient(api=api)

--- a/src/firefly/application.py
+++ b/src/firefly/application.py
@@ -297,7 +297,7 @@ class FireflyApplication(PyDMApplication):
             action_name="launch_queuemonitor_action",
             text="Queue Monitor",
             slot=self.launch_queuemonitor,
-            shortcut="Ctrl+q",
+            shortcut="Ctrl+Q",
         )
         # Action for showing the beamline scheduling window
         self._setup_window_action(
@@ -363,7 +363,7 @@ class FireflyApplication(PyDMApplication):
                 "pause_runengine_action",
                 "Pause",
                 "fa5s.stopwatch",
-                None,
+                "Ctrl+D",
                 "Pause the current plan at the next checkpoint.",
             ),
             (
@@ -416,23 +416,34 @@ class FireflyApplication(PyDMApplication):
             setattr(self, name, action)
         # Actions that control how the queue operates
         actions = [
-            # Attr, object name, text
-            ("queue_autostart_action", "queue_autostart_action", "&Autoplay"),
-            ("queue_stop_action", "queue_stop_action", "Stop Queue"),
+            # Attr, object name, text, tooltip
+            (
+                "queue_autostart_action",
+                "queue_autostart_action",
+                "&Autoplay",
+                "If enabled, the queue will start when items are added.",
+            ),
+            (
+                "queue_stop_action",
+                "queue_stop_action",
+                "Stop Queue",
+                "Instruct the queue to stop after the current item is done.",
+            ),
             (
                 "queue_open_environment_action",
                 "queue_open_environment_action",
                 "&Open Environment",
+                "If open (checked), the queue server is able to run plans.",
             ),
         ]
-        for attr, obj_name, text in actions:
+        for attr, obj_name, text, tooltip in actions:
             action = QAction()
             action.setObjectName(obj_name)
             action.setText(text)
+            action.setToolTip(tooltip)
             setattr(self, attr, action)
         # Customize some specific actions
         self.queue_autostart_action.setCheckable(True)
-        self.queue_autostart_action.setChecked(True)
         self.queue_stop_action.setCheckable(True)
         self.queue_stop_action.setToolTip(
             "Tell the queueserver to stop after this current plan is done."

--- a/src/firefly/application.py
+++ b/src/firefly/application.py
@@ -21,7 +21,7 @@ from qtpy.QtWidgets import QAction
 from haven import load_config
 from haven import load_instrument as load_haven_instrument
 from haven import registry
-from haven.exceptions import ComponentNotFound
+from haven.exceptions import ComponentNotFound, InvalidConfiguration
 from haven.instrument.device import titelize
 
 from .main_window import FireflyMainWindow, PlanMainWindow
@@ -540,8 +540,10 @@ class FireflyApplication(PyDMApplication):
             try:
                 api = queueserver_api()
             except InvalidConfiguration:
-                log.error("Could not load queueserver API "
-                          "configuration from iconfig.toml file.")
+                log.error(
+                    "Could not load queueserver API "
+                    "configuration from iconfig.toml file."
+                )
                 return
         # Create the client object
         if client is None:

--- a/src/firefly/application.py
+++ b/src/firefly/application.py
@@ -44,7 +44,6 @@ pg.setConfigOption("foreground", (0, 0, 0))
 
 class FireflyApplication(PyDMApplication):
     default_display = None
-    xafs_scan_window = None
 
     # For keeping track of ophyd devices used by the Firefly
     registry: Registry = None

--- a/src/firefly/launcher.py
+++ b/src/firefly/launcher.py
@@ -182,7 +182,7 @@ def main(default_fullscreen=False, default_display="status"):
     asyncio.set_event_loop(event_loop)
 
     # Define devices on the beamline (slow!)
-    app.setup_instrument()
+    app.setup_instrument(load_instrument=not pydm_args.no_instrument)
 
     # Get rid of the splash screen now that we're ready to go
     splash.close()

--- a/src/firefly/main_window.py
+++ b/src/firefly/main_window.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import qtawesome as qta
 from pydm import data_plugins
 from pydm.main_window import PyDMMainWindow
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtGui, QtWidgets
 
 from haven import load_config
 

--- a/src/firefly/main_window.py
+++ b/src/firefly/main_window.py
@@ -120,7 +120,6 @@ class FireflyMainWindow(PyDMMainWindow):
         if hasattr(app, "show_logs_window_action"):
             self.ui.menuView.addAction(app.show_logs_window_action)
         # Setup menu
-        print(type(self.ui.menubar))
         self.ui.menuSetup = QtWidgets.QMenu(self.ui.menubar)
         self.ui.menuSetup.setObjectName("menuSetup")
         self.ui.menuSetup.setTitle("Set&up")

--- a/src/firefly/main_window.py
+++ b/src/firefly/main_window.py
@@ -93,6 +93,12 @@ class FireflyMainWindow(PyDMMainWindow):
         _label = QtWidgets.QLabel()
         _label.setText("Queue:")
         bar.addPermanentWidget(_label)
+        self.ui.queue_length_label = QtWidgets.QLabel()
+        self.ui.queue_length_label.setToolTip(
+            "The length of the queue, not including the running plan."
+        )
+        self.ui.queue_length_label.setText("(??)")
+        bar.addPermanentWidget(self.ui.queue_length_label)
         self.ui.environment_label = QtWidgets.QLabel()
         self.ui.environment_label.setToolTip(
             "The current state of the queue server environment."
@@ -108,11 +114,13 @@ class FireflyMainWindow(PyDMMainWindow):
         bar.addPermanentWidget(self.ui.re_label)
         # Connect signals to the status bar
         app.queue_environment_state_changed.connect(self.ui.environment_label.setText)
+        app.queue_length_changed.connect(self.update_queue_length)
         app.queue_re_state_changed.connect(self.ui.re_label.setText)
         # Log viewer window
         if hasattr(app, "show_logs_window_action"):
             self.ui.menuView.addAction(app.show_logs_window_action)
         # Setup menu
+        print(type(self.ui.menubar))
         self.ui.menuSetup = QtWidgets.QMenu(self.ui.menubar)
         self.ui.menuSetup.setObjectName("menuSetup")
         self.ui.menuSetup.setTitle("Set&up")
@@ -124,6 +132,7 @@ class FireflyMainWindow(PyDMMainWindow):
         self.ui.menubar.addAction(self.ui.queue_menu.menuAction())
         for action in app.queue_action_group.actions():
             self.ui.queue_menu.addAction(action)
+        self.ui.queue_menu.addAction(app.queue_stop_action)
         self.ui.queue_menu.addSeparator()
         # Queue settings for the queue client
         self.ui.queue_menu.addAction(app.launch_queuemonitor_action)
@@ -218,6 +227,9 @@ class FireflyMainWindow(PyDMMainWindow):
         self.ui.menuView.addAction(app.show_status_window_action)
         self.ui.menuSetup.addAction(app.show_bss_window_action)
         self.ui.menuSetup.addAction(app.show_iocs_window_action)
+        # Make tooltips show up for menu actions
+        for menu in [self.ui.menuSetup, self.ui.detectors_menu, self.ui.queue_menu]:
+            menu.setToolTipsVisible(True)
 
     def show_status(self, message, timeout=0):
         """Show a message in the status bar."""
@@ -236,6 +248,9 @@ class FireflyMainWindow(PyDMMainWindow):
         if data_plugins.is_read_only():
             title += " [Read Only Mode]"
         self.setWindowTitle(title)
+
+    def update_queue_length(self, new_length: int):
+        self.ui.queue_length_label.setText(f"({new_length})")
 
 
 class PlanMainWindow(FireflyMainWindow):
@@ -260,7 +275,7 @@ class PlanMainWindow(FireflyMainWindow):
         navbar.addAction(app.resume_runengine_action)
         navbar.addAction(app.stop_runengine_action)
         navbar.addAction(app.abort_runengine_action)
-        navbar.addAction(app.halt_runengine_action)
+        # navbar.addAction(app.halt_runengine_action)
 
     def customize_ui(self):
         super().customize_ui()
@@ -269,14 +284,7 @@ class PlanMainWindow(FireflyMainWindow):
         from .application import FireflyApplication
 
         app = FireflyApplication.instance()
-        app.queue_length_changed.connect(self.set_navbar_visibility)
-
-    @QtCore.Slot(int)
-    def set_navbar_visibility(self, queue_length: int):
-        """Determine whether to make the navbar be visible."""
-        log.debug(f"Setting navbar visibility. Queue length: {queue_length}")
-        navbar = self.ui.navbar
-        navbar.setVisible(queue_length > 0)
+        app.queue_in_use_changed.connect(self.ui.navbar.setVisible)
 
 
 # -----------------------------------------------------------------------------

--- a/src/firefly/plans/line_scan.py
+++ b/src/firefly/plans/line_scan.py
@@ -48,7 +48,7 @@ class LineScanDisplay(display.FireflyDisplay):
         self.ui.num_motor_spin_box.lineEdit().setReadOnly(True)
         self.ui.num_motor_spin_box.valueChanged.connect(self.update_regions)
 
-        self.ui.run_button.setEnabled(True)  # for testing
+        # Connect signals for executing the plan
         self.ui.run_button.clicked.connect(self.queue_plan)
 
         # when selections of detectors changed update_total_time

--- a/src/firefly/plans/move_motor_window.py
+++ b/src/firefly/plans/move_motor_window.py
@@ -41,7 +41,6 @@ class MoveMotorDisplay(display.FireflyDisplay):
         self.ui.num_motor_spin_box.lineEdit().setReadOnly(True)
         self.ui.num_motor_spin_box.valueChanged.connect(self.update_regions)
 
-        self.ui.run_button.setEnabled(True)  # for testing
         self.ui.run_button.clicked.connect(self.queue_plan)
 
     def time_converter(self, total_seconds):

--- a/src/firefly/plans/xafs_scan.py
+++ b/src/firefly/plans/xafs_scan.py
@@ -257,7 +257,6 @@ class XafsScanDisplay(display.FireflyDisplay):
         self.ui.pushButton.clicked.connect(self.reset_default_regions)
 
         # Button to actually execute the plan
-        self.ui.run_button.setEnabled(True)
         self.ui.run_button.clicked.connect(self.queue_plan)
 
         # connect checkboxes with all regions' check box

--- a/src/firefly/queue_button.py
+++ b/src/firefly/queue_button.py
@@ -1,9 +1,14 @@
 """A QPushButton that responds to the state of the queue server."""
-
+from strenum import StrEnum
 import qtawesome as qta
 from qtpy import QtGui, QtWidgets
 
 from firefly import FireflyApplication
+
+
+class Colors(StrEnum):
+    ADD_TO_QUEUE = "rgb(0, 123, 255)"
+    RUN_QUEUE = "rgb(25, 135, 84)"
 
 
 class QueueButton(QtWidgets.QPushButton):
@@ -22,11 +27,10 @@ class QueueButton(QtWidgets.QPushButton):
             # Should be disabled because the queue is closed
             self.setDisabled(True)
         # Coloration for the whether the item would get run immediately
-        app = FireflyApplication.instance()
-        if status["re_state"] == "idle" and app.queue_autostart_action.isChecked():
+        if status["re_state"] == "idle" and status["queue_autostart_enabled"]:
             # Will play immediately
             self.setStyleSheet(
-                "background-color: rgb(25, 135, 84);\nborder-color: rgb(25, 135, 84);"
+                f"background-color: {Colors.RUN_QUEUE};\nborder-color: {Colors.RUN_QUEUE};"
             )
             self.setIcon(qta.icon("fa5s.play"))
             self.setText("Run")
@@ -34,7 +38,7 @@ class QueueButton(QtWidgets.QPushButton):
         elif status["worker_environment_exists"]:
             # Will be added to the queue
             self.setStyleSheet(
-                "background-color: rgb(0, 123, 255);\nborder-color: rgb(0, 123, 255);"
+                f"background-color: {Colors.ADD_TO_QUEUE};\nborder-color: {Colors.ADD_TO_QUEUE};"
             )
             self.setIcon(qta.icon("fa5s.list"))
             self.setText("Add to Queue")

--- a/src/firefly/queue_button.py
+++ b/src/firefly/queue_button.py
@@ -1,7 +1,8 @@
 """A QPushButton that responds to the state of the queue server."""
-from strenum import StrEnum
+
 import qtawesome as qta
 from qtpy import QtGui, QtWidgets
+from strenum import StrEnum
 
 from firefly import FireflyApplication
 

--- a/src/firefly/queue_client.py
+++ b/src/firefly/queue_client.py
@@ -9,7 +9,7 @@ from qasync import asyncSlot
 from qtpy.QtCore import QObject, QTimer, Signal
 
 from haven import load_config
-from haven.exceptions import UnknownDeviceConfiguration, InvalidConfiguration
+from haven.exceptions import InvalidConfiguration
 
 log = logging.getLogger()
 
@@ -18,7 +18,9 @@ def queueserver_api():
     try:
         config = load_config()["queueserver"]
     except KeyError:
-        raise InvalidConfiguration("Could not load queueserver info from iconfig.toml file.")
+        raise InvalidConfiguration(
+            "Could not load queueserver info from iconfig.toml file."
+        )
     ctrl_addr = f"tcp://{config['control_host']}:{config['control_port']}"
     info_addr = f"tcp://{config['info_host']}:{config['info_port']}"
     api = REManagerAPI(zmq_control_addr=ctrl_addr, zmq_info_addr=info_addr)

--- a/src/firefly/queue_client.py
+++ b/src/firefly/queue_client.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import warnings
-from typing import Optional, Mapping
+from typing import Mapping, Optional
 
 from bluesky_queueserver_api import comm_base
 from bluesky_queueserver_api.zmq.aio import REManagerAPI
@@ -111,7 +111,7 @@ class QueueClient(QObject):
             await self.check_queue_status(force=True)
         else:
             await self.check_queue_status(force=False)
-    
+
     @asyncSlot(bool)
     async def toggle_autostart(self, enable: bool):
         log.debug(f"Toggling auto-start: {enable}")
@@ -181,7 +181,6 @@ class QueueClient(QObject):
             log.error(msg)
             raise RuntimeError(msg)
 
-
     @asyncSlot()
     async def check_queue_status(self, force=False, *args, **kwargs):
         """Get an update queue status from queue server and notify slots.
@@ -228,8 +227,13 @@ class QueueClient(QObject):
         """
         new_status = await self.api.status()
         # Add a new key for whether the queue is busy (length > 0 or running)
-        has_queue = new_status['items_in_queue'] > 0
-        is_running = new_status['manager_state'] in ["paused", "starting_queue", "executing_queue", "executing_task"]
+        has_queue = new_status["items_in_queue"] > 0
+        is_running = new_status["manager_state"] in [
+            "paused",
+            "starting_queue",
+            "executing_queue",
+            "executing_task",
+        ]
         new_status.setdefault("in_use", has_queue or is_running)
         # Check individual components of the status if they've changed
         signals_to_check = [

--- a/src/firefly/queue_client.py
+++ b/src/firefly/queue_client.py
@@ -9,12 +9,16 @@ from qasync import asyncSlot
 from qtpy.QtCore import QObject, QTimer, Signal
 
 from haven import load_config
+from haven.exceptions import UnknownDeviceConfiguration, InvalidConfiguration
 
 log = logging.getLogger()
 
 
 def queueserver_api():
-    config = load_config()["queueserver"]
+    try:
+        config = load_config()["queueserver"]
+    except KeyError:
+        raise InvalidConfiguration("Could not load queueserver info from iconfig.toml file.")
     ctrl_addr = f"tcp://{config['control_host']}:{config['control_port']}"
     info_addr = f"tcp://{config['info_host']}:{config['info_port']}"
     api = REManagerAPI(zmq_control_addr=ctrl_addr, zmq_info_addr=info_addr)

--- a/src/firefly/tests/test_main_window.py
+++ b/src/firefly/tests/test_main_window.py
@@ -21,12 +21,12 @@ def test_navbar_autohide(ffapp, qtbot):
     window.show()
     navbar = window.ui.navbar
     # Pretend the queue has some things in it
-    with qtbot.waitSignal(ffapp.queue_length_changed):
-        ffapp.queue_length_changed.emit(3)
+    with qtbot.waitSignal(ffapp.queue_in_use_changed):
+        ffapp.queue_in_use_changed.emit(True)
     assert navbar.isVisible()
     # Make the queue be empty
-    with qtbot.waitSignal(ffapp.queue_length_changed):
-        ffapp.queue_length_changed.emit(0)
+    with qtbot.waitSignal(ffapp.queue_in_use_changed):
+        ffapp.queue_in_use_changed.emit(False)
     assert not navbar.isVisible()
 
 

--- a/src/firefly/tests/test_queue_button.py
+++ b/src/firefly/tests/test_queue_button.py
@@ -1,4 +1,4 @@
-from firefly.queue_button import QueueButton, Colors
+from firefly.queue_button import Colors, QueueButton
 
 
 def test_queue_button_style(ffapp):

--- a/src/firefly/tests/test_queue_button.py
+++ b/src/firefly/tests/test_queue_button.py
@@ -1,31 +1,44 @@
-from firefly.queue_button import QueueButton
+from firefly.queue_button import QueueButton, Colors
 
 
 def test_queue_button_style(ffapp):
-    """Does the queue button change color/icon based."""
+    """Does the queue button change color/icon based on the queue state."""
     btn = QueueButton()
     # Initial style should be disabled and plain
     assert not btn.isEnabled()
     assert btn.styleSheet() == ""
-    # State when queue server is open and idle
+    # State when queue server is open and idle (no autostart)
     queue_state = {
         "worker_environment_exists": True,
         "items_in_queue": 0,
         "re_state": "idle",
+        "queue_autostart_enabled": False,
     }
     ffapp.queue_status_changed.emit(queue_state)
     assert btn.isEnabled()
-    assert "rgb(25, 135, 84)" in btn.styleSheet()
+    assert Colors.ADD_TO_QUEUE in btn.styleSheet()
+    assert btn.text() == "Add to Queue"
+    # State when queue server is open and idle (w/ autostart)
+    queue_state = {
+        "worker_environment_exists": True,
+        "items_in_queue": 0,
+        "re_state": "idle",
+        "queue_autostart_enabled": True,
+    }
+    ffapp.queue_status_changed.emit(queue_state)
+    assert btn.isEnabled()
+    assert Colors.RUN_QUEUE in btn.styleSheet()
     assert btn.text() == "Run"
     # State when queue server is open and idle
     queue_state = {
         "worker_environment_exists": True,
         "items_in_queue": 0,
         "re_state": "running",
+        "queue_autostart_enabled": True,
     }
     ffapp.queue_status_changed.emit(queue_state)
     assert btn.isEnabled()
-    assert "rgb(0, 123, 255)" in btn.styleSheet()
+    assert Colors.ADD_TO_QUEUE in btn.styleSheet()
     assert btn.text() == "Add to Queue"
 
 

--- a/src/firefly/tests/test_queue_client.py
+++ b/src/firefly/tests/test_queue_client.py
@@ -334,6 +334,7 @@ def test_autostart_changed(client, ffapp):
 #     qtbot.wait(1000)
 #     client.api.queue_start.assert_called_once()
 
+
 @pytest.mark.asyncio
 async def test_stop_queue(client, qtbot):
     """Test how queuing a plan starts the runengine."""
@@ -350,15 +351,12 @@ async def test_stop_queue(client, qtbot):
 
 
 def test_queue_stopped(client, ffapp):
-    """Does the action respond to changes in the queue stopped pending?
-
-    """
+    """Does the action respond to changes in the queue stopped pending?"""
     assert not ffapp.queue_stop_action.isChecked()
     client.queue_stop_changed.emit(True)
     assert ffapp.queue_stop_action.isChecked()
     client.queue_stop_changed.emit(False)
     assert not ffapp.queue_stop_action.isChecked()
-
 
 
 @pytest.mark.asyncio

--- a/src/firefly/tests/test_queue_client.py
+++ b/src/firefly/tests/test_queue_client.py
@@ -16,6 +16,7 @@ qs_status = {
     "running_item_uid": None,
     "manager_state": "idle",
     "queue_stop_pending": False,
+    "queue_autostart_enabled": False,
     "worker_environment_exists": False,
     "worker_environment_state": "closed",
     "worker_background_tasks": 0,
@@ -218,9 +219,24 @@ def client():
     api.queue_start.return_value = {
         "success": True,
     }
+    api.re_resume.return_value = {
+        "success": True,
+    }
+    api.re_stop.return_value = {
+        "success": True,
+    }
+    api.re_abort.return_value = {
+        "success": True,
+    }
+    api.re_halt.return_value = {
+        "success": True,
+    }
     api.devices_allowed.return_value = {"success": True, "devices_allowed": {}}
     api.environment_open.return_value = {"success": True}
     api.environment_close.return_value = {"success": True}
+    api.queue_autostart.return_value = {"success": True}
+    api.queue_stop.return_value = {"success": True}
+    api.queue_stop_cancel.return_value = {"success": True}
     # Create the client using the fake API
     autoplay_action = QAction()
     autoplay_action.setCheckable(True)
@@ -228,6 +244,12 @@ def client():
     open_environment_action.setCheckable(True)
     client = queue_client.QueueClient(api=api)
     yield client
+
+
+@pytest.fixture()
+def ffapp(ffapp, client):
+    ffapp.prepare_queue_client(api=client.api, client=client)
+    return ffapp
 
 
 def test_client_timer(client):
@@ -252,6 +274,22 @@ async def test_queue_re_control(client):
     await client.start_queue()
     # Check if the queue started
     api.queue_start.assert_called_once()
+    # Resume a paused queue
+    api.reset_mock()
+    await client.resume_runengine()
+    api.re_resume.assert_called_once()
+    # Stop a paused queue
+    api.reset_mock()
+    await client.stop_runengine()
+    api.re_stop.assert_called_once()
+    # Abort a paused queue
+    api.reset_mock()
+    await client.abort_runengine()
+    api.re_abort.assert_called_once()
+    # Halt a paused queue
+    api.reset_mock()
+    await client.halt_runengine()
+    api.re_halt.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -269,7 +307,7 @@ async def test_run_plan(client, qtbot):
 
 
 @pytest.mark.asyncio
-async def test_autoplay(client, qtbot):
+async def test_toggle_autostart(client, qtbot):
     """Test how queuing a plan starts the runengine."""
     api = client.api
     # Check that it doesn't start the queue if the autoplay action is off
@@ -277,6 +315,50 @@ async def test_autoplay(client, qtbot):
     # Check the queue was started now that autoplay is on
     await client.toggle_autostart(True)
     api.queue_autostart.assert_called_once_with(True)
+
+
+def test_autostart_changed(client, ffapp):
+    """Does the action respond to changes in the queue autostart
+    status?
+
+    """
+    assert ffapp.queue_autostart_action.isChecked()
+    client.autostart_changed.emit(False)
+    assert not ffapp.queue_autostart_action.isChecked()
+    client.autostart_changed.emit(True)
+    assert ffapp.queue_autostart_action.isChecked()
+
+
+# def test_start_queue(ffapp, client, qtbot):
+#     ffapp.start_queue_action.trigger()
+#     qtbot.wait(1000)
+#     client.api.queue_start.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_stop_queue(client, qtbot):
+    """Test how queuing a plan starts the runengine."""
+    api = client.api
+    # Check that it doesn't start the queue if the autoplay action is off
+    assert not api.queue_autostart.called
+    # Check the queue stop was requested
+    await client.stop_queue(True)
+    api.queue_stop.assert_called_once()
+    # Check the queue stop can be cancelled
+    api.clear_mock()
+    await client.stop_queue(False)
+    api.queue_stop_cancel.assert_called_once()
+
+
+def test_queue_stopped(client, ffapp):
+    """Does the action respond to changes in the queue stopped pending?
+
+    """
+    assert not ffapp.queue_stop_action.isChecked()
+    client.queue_stop_changed.emit(True)
+    assert ffapp.queue_stop_action.isChecked()
+    client.queue_stop_changed.emit(False)
+    assert not ffapp.queue_stop_action.isChecked()
+
 
 
 @pytest.mark.asyncio
@@ -287,7 +369,9 @@ async def test_check_queue_status(client, qtbot):
         client.environment_opened,
         client.environment_state_changed,
         client.re_state_changed,
+        client.autostart_changed,
         client.manager_state_changed,
+        client.in_use_changed,
     ]
     with qtbot.waitSignals(signals):
         await client.check_queue_status()

--- a/src/firefly/tests/test_xafs_scan.py
+++ b/src/firefly/tests/test_xafs_scan.py
@@ -155,6 +155,7 @@ def test_xafs_scan_plan_queued_energies(ffapp, qtbot):
         return True
 
     # Click the run button and see if the plan is queued
+    display.ui.run_button.setEnabled(True)
     with qtbot.waitSignal(
         ffapp.queue_item_added, timeout=1000, check_params_cb=check_item
     ):
@@ -262,6 +263,7 @@ def test_xafs_scan_plan_queued_energies_k_mixed(ffapp, qtbot):
         return True
 
     # Click the run button and see if the plan is queued
+    display.ui.run_button.setEnabled(True)
     with qtbot.waitSignal(
         ffapp.queue_item_added, timeout=1000, check_params_cb=check_item
     ):

--- a/src/haven/exceptions.py
+++ b/src/haven/exceptions.py
@@ -16,25 +16,7 @@ class GainOverflow(RuntimeError):
 
     ...
 
-
-# class ComponentNotFound(IndexError):
-#     """Registry looked for a component, but it wasn't registered."""
-
-#     ...
-
-
-# class MultipleComponentsFound(IndexError):
-#     """Registry looked for a single component, but found more than one."""
-
-#     ...
-
-
-# class InvalidComponentLabel(TypeError):
-#     """Registry looked for a component, but the label provided is not vlaid."""
-
-#     ...
-
-
+    
 class FileNotWritable(IOError):
     """Output file is available but does not have write intent."""
 
@@ -71,7 +53,11 @@ class IOCTimeout(RuntimeError):
     ...
 
 
-class UnknownDeviceConfiguration(ValueError):
+class InvalidConfiguration(ValueError):
+    """The configuration files for Haven are missing keys."""
+    ...
+
+class UnknownDeviceConfiguration(InvalidConfiguration):
     """The configuration for a device does not match the known options."""
 
     ...

--- a/src/haven/exceptions.py
+++ b/src/haven/exceptions.py
@@ -16,7 +16,7 @@ class GainOverflow(RuntimeError):
 
     ...
 
-    
+
 class FileNotWritable(IOError):
     """Output file is available but does not have write intent."""
 
@@ -55,7 +55,9 @@ class IOCTimeout(RuntimeError):
 
 class InvalidConfiguration(ValueError):
     """The configuration files for Haven are missing keys."""
+
     ...
+
 
 class UnknownDeviceConfiguration(InvalidConfiguration):
     """The configuration for a device does not match the known options."""

--- a/src/haven/instrument/ion_chamber.py
+++ b/src/haven/instrument/ion_chamber.py
@@ -620,7 +620,7 @@ async def make_ion_chamber_device(
         ch_num=ch_num,
         name=name,
         preamp_prefix=preamp_prefix,
-        labels={"ion_chambers"},
+        labels={"ion_chambers", "detectors"},
     )
     try:
         await await_for_connection(ic)
@@ -733,7 +733,7 @@ def load_ion_chambers(config=None):
                     name=defn["name"],
                     preamp_prefix=defn["preamp_prefix"],
                     voltmeter_prefix=defn["voltmeter_prefix"],
-                    labels={"ion_chambers", defn["section"]},
+                    labels={"ion_chambers", defn["section"], "detectors"},
                     counts_per_volt_second=defn["counts_per_volt_second"],
                 )
             )

--- a/src/haven/instrument/motor.py
+++ b/src/haven/instrument/motor.py
@@ -72,8 +72,7 @@ def load_motors(
         prefix = config["prefix"]
         num_motors = config["num_motors"]
         log.info(
-            f"Preparing {num_motors} motors from IOC: "
-            f"{section_name} ({prefix})"
+            f"Preparing {num_motors} motors from IOC: " f"{section_name} ({prefix})"
         )
         for idx in range(num_motors):
             motor_prefix = f"{prefix}m{idx+1}"

--- a/src/haven/instrument/motor.py
+++ b/src/haven/instrument/motor.py
@@ -72,7 +72,8 @@ def load_motors(
         prefix = config["prefix"]
         num_motors = config["num_motors"]
         log.info(
-            f"Preparing {num_motors} motors from IOC: " "{section_name} ({prefix})"
+            f"Preparing {num_motors} motors from IOC: "
+            f"{section_name} ({prefix})"
         )
         for idx in range(num_motors):
             motor_prefix = f"{prefix}m{idx+1}"


### PR DESCRIPTION
Finished out the run engine control actions, plus the ability to request the queue stop after the current scan. Status bar now shows how many items are in the queue. Autostart action responds to changes in the queueserver's autostart state. Bunch of other UX improvements too.