### PR TITLE
Use bluesky plans when saving motor positions

### DIFF
--- a/src/haven/catalog.py
+++ b/src/haven/catalog.py
@@ -198,9 +198,9 @@ class CatalogScan:
     def __init__(self, container):
         self.container = container
 
-    def _read_data(self, signals):
+    def _read_data(self, signals, dataset="primary/data"):
         # Fetch data if needed
-        data = self.container["primary"]["data"]
+        data = self.container[dataset]
         return data.read(signals)
 
     def _read_metadata(self, keys=None):
@@ -220,6 +220,9 @@ class CatalogScan:
     def formats(self):
         return self.container.formats
 
+    async def data(self, stream="primary"):
+        return await self.loop.run_in_executor(None, self._read_data, None, f"{stream}/data")
+
     async def to_dataframe(self, signals=None):
         """Convert the dataset into a pandas dataframe."""
         xarray = await self.loop.run_in_executor(None, self._read_data, signals)
@@ -232,6 +235,10 @@ class CatalogScan:
     @property
     def loop(self):
         return asyncio.get_running_loop()
+
+    async def data_keys(self, stream="primary"):
+        stream_md = await self.loop.run_in_executor(None, self._read_metadata, stream)
+        return stream_md['descriptors']['data_keys']
 
     async def hints(self):
         """Retrieve the data hints for this scan.

--- a/src/haven/catalog.py
+++ b/src/haven/catalog.py
@@ -221,7 +221,9 @@ class CatalogScan:
         return self.container.formats
 
     async def data(self, stream="primary"):
-        return await self.loop.run_in_executor(None, self._read_data, None, f"{stream}/data")
+        return await self.loop.run_in_executor(
+            None, self._read_data, None, f"{stream}/data"
+        )
 
     async def to_dataframe(self, signals=None):
         """Convert the dataset into a pandas dataframe."""
@@ -238,7 +240,7 @@ class CatalogScan:
 
     async def data_keys(self, stream="primary"):
         stream_md = await self.loop.run_in_executor(None, self._read_metadata, stream)
-        return stream_md['descriptors']['data_keys']
+        return stream_md["descriptors"]["data_keys"]
 
     async def hints(self):
         """Retrieve the data hints for this scan.

--- a/src/haven/instrument/__init__.py
+++ b/src/haven/instrument/__init__.py
@@ -1,7 +1,7 @@
 from .instrument_registry import InstrumentRegistry, registry  # noqa: F401
 from .ion_chamber import IonChamber  # noqa: F401
 from .monochromator import Monochromator  # noqa: F401
-from .motor import HavenMotor  # noqa: F401
+from .motor import HavenMotor, Motor  # noqa: F401
 from .robot import Robot, load_robots  # noqa: F401
 from .table import Table, load_tables  # noqa: F401
 

--- a/src/haven/instrument/motor.py
+++ b/src/haven/instrument/motor.py
@@ -79,9 +79,9 @@ class Motor(MotorBase):
         # Configuration signals
         with self.add_children_as_readables(ConfigSignal):
             self.description = epics_signal_rw(str, f"{prefix}.DESC")
-            self.calibration_offset = epics_signal_rw(float, f"{prefix}.OFF")
-            self.calibration_direction = epics_signal_rw(SubsetEnum["Pos", "Neg"], f"{prefix}.DIR")
-            self.calibration_mode = epics_signal_rw(SubsetEnum["Variable", "Frozen"], f"{prefix}.FOFF")
+            self.user_offset = epics_signal_rw(float, f"{prefix}.OFF")
+            self.user_offset_dir = epics_signal_rw(SubsetEnum["Pos", "Neg"], f"{prefix}.DIR")
+            self.offset_freeze_switch = epics_signal_rw(SubsetEnum["Variable", "Frozen"], f"{prefix}.FOFF")
         # Motor status signals
         self.motor_is_moving = epics_signal_r(int, f"{prefix}.MOVN")
         self.motor_done_move = epics_signal_r(int, f"{prefix}.DMOV")

--- a/src/haven/instrument/motor.py
+++ b/src/haven/instrument/motor.py
@@ -13,6 +13,7 @@ from ophyd_async.core import (
     ConfigSignal,
     SignalBackend,
     SignalX,
+    SubsetEnum,
 )
 from ophyd_async.epics.motor import Motor as MotorBase
 from ophyd_async.epics.signal import epics_signal_r, epics_signal_rw
@@ -78,6 +79,9 @@ class Motor(MotorBase):
         # Configuration signals
         with self.add_children_as_readables(ConfigSignal):
             self.description = epics_signal_rw(str, f"{prefix}.DESC")
+            self.calibration_offset = epics_signal_rw(float, f"{prefix}.OFF")
+            self.calibration_direction = epics_signal_rw(SubsetEnum["Pos", "Neg"], f"{prefix}.DIR")
+            self.calibration_mode = epics_signal_rw(SubsetEnum["Variable", "Frozen"], f"{prefix}.FOFF")
         # Motor status signals
         self.motor_is_moving = epics_signal_r(int, f"{prefix}.MOVN")
         self.motor_done_move = epics_signal_r(int, f"{prefix}.DMOV")

--- a/src/haven/instrument/motor.py
+++ b/src/haven/instrument/motor.py
@@ -80,8 +80,12 @@ class Motor(MotorBase):
         with self.add_children_as_readables(ConfigSignal):
             self.description = epics_signal_rw(str, f"{prefix}.DESC")
             self.user_offset = epics_signal_rw(float, f"{prefix}.OFF")
-            self.user_offset_dir = epics_signal_rw(SubsetEnum["Pos", "Neg"], f"{prefix}.DIR")
-            self.offset_freeze_switch = epics_signal_rw(SubsetEnum["Variable", "Frozen"], f"{prefix}.FOFF")
+            self.user_offset_dir = epics_signal_rw(
+                SubsetEnum["Pos", "Neg"], f"{prefix}.DIR"
+            )
+            self.offset_freeze_switch = epics_signal_rw(
+                SubsetEnum["Variable", "Frozen"], f"{prefix}.FOFF"
+            )
         # Motor status signals
         self.motor_is_moving = epics_signal_r(int, f"{prefix}.MOVN")
         self.motor_done_move = epics_signal_r(int, f"{prefix}.DMOV")

--- a/src/haven/motor_position.py
+++ b/src/haven/motor_position.py
@@ -245,30 +245,21 @@ async def get_motor_positions(
         yield await MotorPosition.aload(run)
 
 
-def recall_motor_position(
-    uid: str | None = None, name: str | None = None, collection=None
-):
+def recall_motor_position(uid: str):
     """Set motors to their previously saved positions.
 
     Parameters
     ==========
     uid
       The universal identifier for the the document in the collection.
-    name
-      The name of the saved motor position, as given with the *name*
-      parameter to the ``save_motor_position`` function.
-    collection
-      The mongodb collection from which to print motor positions.
 
     """
-    # Get default collection if none was given
-    if collection is None:
-        collection = default_collection()
     # Get the saved position from the database
-    position = get_motor_position(uid=uid, name=name, collection=collection)
+    position = get_motor_position(uid=uid)
     # Create a move plan to recall the position
     plan_args = []
     for axis in position.motors:
+        print(axis.name)
         motor = registry.find(name=axis.name)
         plan_args.append(motor)
         plan_args.append(axis.readback)

--- a/src/haven/tests/test_save_motor_positions.py
+++ b/src/haven/tests/test_save_motor_positions.py
@@ -1,15 +1,20 @@
+from unittest.mock import MagicMock
 import datetime as dt
 import logging
 import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+import pandas as pd
 import pytest
 import time_machine
-from ophyd import Component as Cpt
-from ophyd import Signal
-from ophyd.sim import SynAxis, motor1
+from tiled.adapters.mapping import MapAdapter
+from tiled.adapters.xarray import DatasetAdapter
+from tiled.client import Context, from_context
+from tiled.server.app import build_app
 
+from haven.instrument import Motor
+from haven.catalog import Catalog
 from haven import (
     get_motor_position,
     list_current_motor_positions,
@@ -20,25 +25,197 @@ from haven import (
 
 log = logging.getLogger(__name__)
 
-# Use a timezone we're not likely to be in for testing tz-aware behavior
-fake_time = dt.datetime(2022, 8, 19, 19, 10, 51, tzinfo=ZoneInfo("Asia/Taipei"))
+# Metadata from real scan
+# {'start': {'EPICS_CA_MAX_ARRAY_BYTES': '16777216',
+#            'EPICS_HOST_ARCH': 'rhel8-x86_64',
+#            'beamline_id': '25-ID-C (Dev)',
+#            'detectors': ['sim_motor_2'],
+#            'epics_libca': '/home/beams0/S25IDCUSER/micromamba/envs/haven-dev/lib/python3.10/site-packages/epicscorelibs/lib/libca.so.7.0.7.99.0',
+#            'facility_id': 'Advanced Photon Source',
+#            'hints': {'dimensions': [[['time'], 'primary']]},
+#            'login_id': 's25idcuser@microprobe.xray.aps.anl.gov',
+#            'num_intervals': 0,
+#            'num_points': 1,
+#            'parameters': '',
+#            'pid': 2700346,
+#            'plan_args': {'delay': None,
+#                          'detectors': ['<haven.instrument.motor.Motor object '
+#                                        'at 0x7f9c831ca650>'],
+#                          'num': 1},
+#            'plan_name': 'save_motor_position',
+#            'plan_type': 'generator',
+#            'position_name': 'test',
+#            'purpose': 'testing save motor positions',
+#            'sample_name': '',
+#            'scan_id': 2,
+#            'time': 1725897133.9880543,
+#            'uid': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd',
+#            'versions': {'apstools': '1.6.20',
+#                         'bluesky': '1.13.0a4',
+#                         'databroker': '1.2.5',
+#                         'epics': '3.5.6',
+#                         'epics_ca': '3.5.6',
+#                         'h5py': '3.11.0',
+#                         'haven': '2024.8.2',
+#                         'matplotlib': '3.9.1.post1',
+#                         'numpy': '1.26.4',
+#                         'ophyd': '1.9.0',
+#                         'pymongo': '4.8.0'},
+#            'xray_source': 'undulator: ID25ds:'},
+#  'stop': {'exit_status': 'success',
+#           'num_events': {'primary': 1},
+#           'reason': '',
+#           'run_start': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd',
+#           'time': 1725897134.0116587,
+#           'uid': 'b6a2cf81-0328-489f-bfcc-967af6207e1b'},
+#  'summary': {'datetime': datetime.datetime(2024, 9, 9, 15, 52, 13, 988054, tzinfo=datetime.timezone.utc),
+#              'duration': 0.023604393005371094,
+#              'plan_name': 'save_motor_position',
+#              'scan_id': 2,
+#              'stream_names': ['primary'],
+#              'timestamp': 1725897133.9880543,
+#              'uid': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd'}}
 
-IOC_timeout = 40  # Wait up to this many seconds for the IOC to be ready
+## Primary stream metadata
 
-motor_prefix = "255idVME:"
+# {'descriptors': [{'configuration': {'sim_motor_2': {'data': {'sim_motor_2-description': 'sim_motor_2',
+#                                                              'sim_motor_2-motor_egu': 'degrees',
+#                                                              'sim_motor_2-velocity': 1.0},
+#                                                     'data_keys': {'sim_motor_2-description': {'dtype': 'string',
+#                                                                                               'dtype_numpy': '|S40',
+#                                                                                               'limits': {'alarm': {'high': None,
+#                                                                                                                    'low': None},
+#                                                                                                          'control': {'high': None,
+#                                                                                                                      'low': None},
+#                                                                                                          'display': {'high': None,
+#                                                                                                                      'low': None},
+#                                                                                                          'warning': {'high': None,
+#                                                                                                                      'low': None}},
+#                                                                                               'shape': [],
+#                                                                                               'source': 'ca://25idc:simMotor:m2.DESC'},
+#                                                                   'sim_motor_2-motor_egu': {'dtype': 'string',
+#                                                                                             'dtype_numpy': '|S40',
+#                                                                                             'limits': {'alarm': {'high': None,
+#                                                                                                                  'low': None},
+#                                                                                                        'control': {'high': None,
+#                                                                                                                    'low': None},
+#                                                                                                        'display': {'high': None,
+#                                                                                                                    'low': None},
+#                                                                                                        'warning': {'high': None,
+#                                                                                                                    'low': None}},
+#                                                                                             'shape': [],
+#                                                                                             'source': 'ca://25idc:simMotor:m2.EGU'},
+#                                                                   'sim_motor_2-velocity': {'dtype': 'number',
+#                                                                                            'dtype_numpy': '<f8',
+#                                                                                            'limits': {'alarm': {'high': None,
+#                                                                                                                 'low': None},
+#                                                                                                       'control': {'high': 200.0,
+#                                                                                                                   'low': 0.1},
+#                                                                                                       'display': {'high': 200.0,
+#                                                                                                                   'low': 0.1},
+#                                                                                                       'warning': {'high': None,
+#                                                                                                                   'low': None}},
+#                                                                                            'precision': 5,
+#                                                                                            'shape': [],
+#                                                                                            'source': 'ca://25idc:simMotor:m2.VELO',
+#                                                                                            'units': 'degrees'}},
+#                                                     'timestamps': {'sim_motor_2-description': 1725483808.090941,
+#                                                                    'sim_motor_2-motor_egu': 1725483808.090941,
+#                                                                    'sim_motor_2-velocity': 1725483808.090941}}},
+#                   'data_keys': {'sim_motor_2': {'dtype': 'number',
+#                                                 'dtype_numpy': '<f8',
+#                                                 'limits': {'alarm': {'high': None,
+#                                                                      'low': None},
+#                                                            'control': {'high': 32000.0,
+#                                                                        'low': -32000.0},
+#                                                            'display': {'high': 32000.0,
+#                                                                        'low': -32000.0},
+#                                                            'warning': {'high': None,
+#                                                                        'low': None}},
+#                                                 'object_name': 'sim_motor_2',
+#                                                 'precision': 5,
+#                                                 'shape': [],
+#                                                 'source': 'ca://25idc:simMotor:m2.RBV',
+#                                                 'units': 'degrees'}},
+#                   'hints': {'sim_motor_2': {'fields': ['sim_motor_2']}},
+#                   'name': 'primary',
+#                   'object_keys': {'sim_motor_2': ['sim_motor_2']},
+#                   'run_start': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd',
+#                   'time': 1725897133.99685,
+#                   'uid': 'fcb35152-cb8c-46e8-b923-d07eec666070'}],
+#  'stream_name': 'primary'}
 
 
-class FakeHavenMotor(SynAxis):
-    user_offset = Cpt(Signal, value=0, kind="config")
+# Config data from above run
+# In [48]: run['primary/config/sim_motor_2'].read().compute()
+# Out[48]: 
+# <xarray.Dataset> Size: 24B
+# Dimensions:                  (time: 1)
+# Dimensions without coordinates: time
+# Data variables:
+#     sim_motor_2-description  (time) object 8B 'sim_motor_2'
+#     sim_motor_2-motor_egu    (time) object 8B 'degrees'
+#     sim_motor_2-velocity     (time) float64 8B 1.0
+
+
+position_runs = {
+    "a9b3e0fa-eba1-43e0-a38c-c7ac76278000": MapAdapter(
+        {
+            "primary": MapAdapter(
+                {
+                    "data": DatasetAdapter.from_dataset(pd.DataFrame({
+                        "motorA": [12.0],
+                        "motorB": [-113.25],
+                    }).to_xarray()),
+                },
+                metadata={
+                    "descriptors": {
+                        "data_keys": {
+                            "motorA": {
+                                "object_name": "motorA"
+                            },
+                            "motorB": {
+                                "object_name": "motorB"
+                            },
+                        },
+                    },
+                }
+            ),
+        },
+        metadata={
+            "start": {
+                'plan_name': 'save_motor_position',
+                "position_name": "Good position A",
+                'time': 1725897133.9880543,
+                'uid': "a9b3e0fa-eba1-43e0-a38c-c7ac76278000",
+            },
+        },
+    ),
+    "1b7f2ef5-6a3c-496e-9f6f-f1a4805c0065": MapAdapter({}),
+}
+
+
+@pytest.fixture()
+def client(mocker):
+    tree = MapAdapter(position_runs)
+    app = build_app(tree)
+    with Context.from_app(app) as context:
+        client = from_context(context)
+        mocker.patch("haven.motor_position.tiled_client",
+                     MagicMock(return_value=client))
+        yield client
 
 
 @pytest.fixture
 def motors(sim_registry):
     # Create the motors
-    return [
-        FakeHavenMotor(name="motor_B"),
-        FakeHavenMotor(name="motor_A"),
+    motors = [
+        Motor("", name="motor_B"),
+        Motor("", name="motor_A"),
     ]
+    for motor in motors:
+        sim_registry.register(motor)
+    return motors
 
 
 def test_save_motor_position_by_device(motors):
@@ -49,7 +226,7 @@ def test_save_motor_position_by_device(motors):
     # Check that the right read messages get emitted
     messages = list(plan)
     # Check that the motors got saved
-    readA, readB = messages[1:3]
+    readA, readB = messages[6:8]
     assert readA.obj is motorA
     assert readB.obj is motorB
 
@@ -63,32 +240,17 @@ def test_save_motor_position_by_name(motors):
     # Check that the right read messages get emitted
     messages = list(plan)
     # Check that the motors got saved
-    readA, readB = messages[1:3]
+    readA, readB = messages[6:8]
     assert readA.obj is motorA
     assert readB.obj is motorB
 
 
-def test_get_motor_position_by_uid(mongodb):
-    uid = str(mongodb.motor_positions.find_one({"name": "Good position A"})["_id"])
-    result = get_motor_position(uid=uid, collection=mongodb.motor_positions)
+async def test_get_motor_position_by_uid(client):
+    uid = "a9b3e0fa-eba1-43e0-a38c-c7ac76278000"
+    result = get_motor_position(uid=uid)
     assert result.name == "Good position A"
-    assert result.motors[0].name == "SLT V Upper"
-    assert result.motors[0].readback == 510.5
-
-
-def test_get_motor_position_by_name(mongodb):
-    result = get_motor_position(
-        name="Good position A", collection=mongodb.motor_positions
-    )
-    assert result.name == "Good position A"
-    assert result.motors[0].name == "SLT V Upper"
-    assert result.motors[0].readback == 510.5
-
-
-def test_get_motor_position_exceptions(mongodb):
-    # Fails when no query params are given
-    with pytest.raises(TypeError):
-        get_motor_position(collection=mongodb.motor_positions)
+    assert result.motors[0].name == "motorA"
+    assert result.motors[0].readback == 12.0
 
 
 def test_recall_motor_position(mongodb, sim_motor_registry):
@@ -105,7 +267,6 @@ def test_recall_motor_position(mongodb, sim_motor_registry):
     assert msg1.args[0] == -211.93
 
 
-@time_machine.travel(fake_time, tick=True)
 def test_list_motor_positions(mongodb, capsys):
     # Do the listing
     list_motor_positions(collection=mongodb.motor_positions)
@@ -150,7 +311,6 @@ def test_motor_position_e2e(mongodb, sim_motor_registry):
     assert msg.args[0] == 504.6
 
 
-@time_machine.travel(fake_time, tick=True)
 def test_list_current_motor_positions(mongodb, capsys):
     # Get our simulated motors into the device registry
     with capsys.disabled():

--- a/src/haven/tests/test_save_motor_positions.py
+++ b/src/haven/tests/test_save_motor_positions.py
@@ -1,8 +1,7 @@
-from unittest.mock import MagicMock
 import datetime as dt
 import logging
-import time
 from datetime import datetime
+from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -15,7 +14,6 @@ from tiled.client import Context, from_context
 from tiled.server.app import build_app
 
 from haven.instrument import Motor
-from haven.catalog import Catalog
 from haven.motor_position import (
     get_motor_position,
     get_motor_positions,
@@ -23,8 +21,6 @@ from haven.motor_position import (
     list_motor_positions,
     recall_motor_position,
     save_motor_position,
-    MotorPosition,
-    MotorAxis,
 )
 
 log = logging.getLogger(__name__)
@@ -267,11 +263,11 @@ position_runs = {
                 "time": 1725897033,
                 "uid": "5dd9a185-d5c4-4c8b-a719-9d7beb9007dc",
             },
-        },        
+        },
     ),
     # A saved motor position, but older
     "42b8c45d-e98d-4f59-9ce8-8f14134c90bd": MapAdapter(
-                {
+        {
             "primary": MapAdapter(
                 {
                     "data": DatasetAdapter.from_dataset(
@@ -303,7 +299,7 @@ position_runs = {
                 "uid": "42b8c45d-e98d-4f59-9ce8-8f14134c90bd",
             },
         },
-    ),    
+    ),
     # A scan that's not a saved motor position
     "9bcd07e9-3188-49d3-a1ce-e3b51ebe48b5": MapAdapter(
         {},
@@ -407,17 +403,20 @@ async def test_list_motor_positions(client, capsys):
     first_motor = captured.out.split("\n\n")[0]
     uid = "a9b3e0fa-eba1-43e0-a38c-c7ac76278000"
     timestamp = "2024-09-09 10:52:13"
-    expected = "\n".join([
-        f'Good position A',
-        f'┃ uid="{uid}", {timestamp}',
-        f"┣━motor_A: 12.0, offset: None",
-        f"┗━motor_B: -113.25, offset: None",
-    ])
+    expected = "\n".join(
+        [
+            f"Good position A",
+            f'┃ uid="{uid}", {timestamp}',
+            f"┣━motor_A: 12.0, offset: None",
+            f"┗━motor_B: -113.25, offset: None",
+        ]
+    )
     assert first_motor == expected
 
 
 # Use a timezone we're not likely to be in for testing tz-aware behavior
 fake_time = dt.datetime(2022, 8, 19, 19, 10, 51, tzinfo=ZoneInfo("Asia/Taipei"))
+
 
 @time_machine.travel(fake_time, tick=True)
 async def test_list_current_motor_positions(motors, capsys):
@@ -434,12 +433,14 @@ async def test_list_current_motor_positions(motors, capsys):
     captured = capsys.readouterr()
     assert len(captured.out) > 0
     timestamp = "2022-08-19 19:10:51"
-    expected = "\n".join([
-        f"Current motor positions",
-        f"┃ {timestamp}",
-        f"┣━motor_A: 11.0, offset: 1.5",
-        f"┗━motor_B: 23.0, offset: 0.0",
-    ])
+    expected = "\n".join(
+        [
+            f"Current motor positions",
+            f"┃ {timestamp}",
+            f"┣━motor_A: 11.0, offset: 1.5",
+            f"┗━motor_B: 23.0, offset: 0.0",
+        ]
+    )
     assert captured.out.strip("\n") == expected.strip("\n")
 
 

--- a/src/haven/tests/test_save_motor_positions.py
+++ b/src/haven/tests/test_save_motor_positions.py
@@ -25,137 +25,8 @@ from haven.motor_position import (
 
 log = logging.getLogger(__name__)
 
-# Metadata from real scan
-# {'start': {'EPICS_CA_MAX_ARRAY_BYTES': '16777216',
-#            'EPICS_HOST_ARCH': 'rhel8-x86_64',
-#            'beamline_id': '25-ID-C (Dev)',
-#            'detectors': ['sim_motor_2'],
-#            'epics_libca': '/home/beams0/S25IDCUSER/micromamba/envs/haven-dev/lib/python3.10/site-packages/epicscorelibs/lib/libca.so.7.0.7.99.0',
-#            'facility_id': 'Advanced Photon Source',
-#            'hints': {'dimensions': [[['time'], 'primary']]},
-#            'login_id': 's25idcuser@microprobe.xray.aps.anl.gov',
-#            'num_intervals': 0,
-#            'num_points': 1,
-#            'parameters': '',
-#            'pid': 2700346,
-#            'plan_args': {'delay': None,
-#                          'detectors': ['<haven.instrument.motor.Motor object '
-#                                        'at 0x7f9c831ca650>'],
-#                          'num': 1},
-#            'plan_name': 'save_motor_position',
-#            'plan_type': 'generator',
-#            'position_name': 'test',
-#            'purpose': 'testing save motor positions',
-#            'sample_name': '',
-#            'scan_id': 2,
-#            'time': 1725897133.9880543,
-#            'uid': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd',
-#            'versions': {'apstools': '1.6.20',
-#                         'bluesky': '1.13.0a4',
-#                         'databroker': '1.2.5',
-#                         'epics': '3.5.6',
-#                         'epics_ca': '3.5.6',
-#                         'h5py': '3.11.0',
-#                         'haven': '2024.8.2',
-#                         'matplotlib': '3.9.1.post1',
-#                         'numpy': '1.26.4',
-#                         'ophyd': '1.9.0',
-#                         'pymongo': '4.8.0'},
-#            'xray_source': 'undulator: ID25ds:'},
-#  'stop': {'exit_status': 'success',
-#           'num_events': {'primary': 1},
-#           'reason': '',
-#           'run_start': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd',
-#           'time': 1725897134.0116587,
-#           'uid': 'b6a2cf81-0328-489f-bfcc-967af6207e1b'},
-#  'summary': {'datetime': datetime.datetime(2024, 9, 9, 15, 52, 13, 988054, tzinfo=datetime.timezone.utc),
-#              'duration': 0.023604393005371094,
-#              'plan_name': 'save_motor_position',
-#              'scan_id': 2,
-#              'stream_names': ['primary'],
-#              'timestamp': 1725897133.9880543,
-#              'uid': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd'}}
-
-## Primary stream metadata
-
-# {'descriptors': [{'configuration': {'sim_motor_2': {'data': {'sim_motor_2-description': 'sim_motor_2',
-#                                                              'sim_motor_2-motor_egu': 'degrees',
-#                                                              'sim_motor_2-velocity': 1.0},
-#                                                     'data_keys': {'sim_motor_2-description': {'dtype': 'string',
-#                                                                                               'dtype_numpy': '|S40',
-#                                                                                               'limits': {'alarm': {'high': None,
-#                                                                                                                    'low': None},
-#                                                                                                          'control': {'high': None,
-#                                                                                                                      'low': None},
-#                                                                                                          'display': {'high': None,
-#                                                                                                                      'low': None},
-#                                                                                                          'warning': {'high': None,
-#                                                                                                                      'low': None}},
-#                                                                                               'shape': [],
-#                                                                                               'source': 'ca://25idc:simMotor:m2.DESC'},
-#                                                                   'sim_motor_2-motor_egu': {'dtype': 'string',
-#                                                                                             'dtype_numpy': '|S40',
-#                                                                                             'limits': {'alarm': {'high': None,
-#                                                                                                                  'low': None},
-#                                                                                                        'control': {'high': None,
-#                                                                                                                    'low': None},
-#                                                                                                        'display': {'high': None,
-#                                                                                                                    'low': None},
-#                                                                                                        'warning': {'high': None,
-#                                                                                                                    'low': None}},
-#                                                                                             'shape': [],
-#                                                                                             'source': 'ca://25idc:simMotor:m2.EGU'},
-#                                                                   'sim_motor_2-velocity': {'dtype': 'number',
-#                                                                                            'dtype_numpy': '<f8',
-#                                                                                            'limits': {'alarm': {'high': None,
-#                                                                                                                 'low': None},
-#                                                                                                       'control': {'high': 200.0,
-#                                                                                                                   'low': 0.1},
-#                                                                                                       'display': {'high': 200.0,
-#                                                                                                                   'low': 0.1},
-#                                                                                                       'warning': {'high': None,
-#                                                                                                                   'low': None}},
-#                                                                                            'precision': 5,
-#                                                                                            'shape': [],
-#                                                                                            'source': 'ca://25idc:simMotor:m2.VELO',
-#                                                                                            'units': 'degrees'}},
-#                                                     'timestamps': {'sim_motor_2-description': 1725483808.090941,
-#                                                                    'sim_motor_2-motor_egu': 1725483808.090941,
-#                                                                    'sim_motor_2-velocity': 1725483808.090941}}},
-#                   'data_keys': {'sim_motor_2': {'dtype': 'number',
-#                                                 'dtype_numpy': '<f8',
-#                                                 'limits': {'alarm': {'high': None,
-#                                                                      'low': None},
-#                                                            'control': {'high': 32000.0,
-#                                                                        'low': -32000.0},
-#                                                            'display': {'high': 32000.0,
-#                                                                        'low': -32000.0},
-#                                                            'warning': {'high': None,
-#                                                                        'low': None}},
-#                                                 'object_name': 'sim_motor_2',
-#                                                 'precision': 5,
-#                                                 'shape': [],
-#                                                 'source': 'ca://25idc:simMotor:m2.RBV',
-#                                                 'units': 'degrees'}},
-#                   'hints': {'sim_motor_2': {'fields': ['sim_motor_2']}},
-#                   'name': 'primary',
-#                   'object_keys': {'sim_motor_2': ['sim_motor_2']},
-#                   'run_start': 'e4a6d3d1-6543-4a42-98a7-a311af23f4cd',
-#                   'time': 1725897133.99685,
-#                   'uid': 'fcb35152-cb8c-46e8-b923-d07eec666070'}],
-#  'stream_name': 'primary'}
-
-
-# Config data from above run
-# In [48]: run['primary/config/sim_motor_2'].read().compute()
-# Out[48]:
-# <xarray.Dataset> Size: 24B
-# Dimensions:                  (time: 1)
-# Dimensions without coordinates: time
-# Data variables:
-#     sim_motor_2-description  (time) object 8B 'sim_motor_2'
-#     sim_motor_2-motor_egu    (time) object 8B 'degrees'
-#     sim_motor_2-velocity     (time) float64 8B 1.0
+# Use a timezone we're not likely to be in for testing tz-aware behavior
+fake_time = dt.datetime(2022, 8, 19, 19, 10, 51, tzinfo=ZoneInfo("Asia/Taipei"))
 
 
 position_runs = {
@@ -394,6 +265,7 @@ def test_recall_motor_position(client, motors):
     assert msg1.args[0] == -113.25
 
 
+@time_machine.travel(fake_time, tick=True)
 async def test_list_motor_positions(client, capsys):
     # Do the listing
     await list_motor_positions()
@@ -402,7 +274,7 @@ async def test_list_motor_positions(client, capsys):
     assert len(captured.out) > 0
     first_motor = captured.out.split("\n\n")[0]
     uid = "a9b3e0fa-eba1-43e0-a38c-c7ac76278000"
-    timestamp = "2024-09-09 10:52:13"
+    timestamp = "2024-09-09 23:52:13"
     expected = "\n".join(
         [
             f"Good position A",
@@ -412,10 +284,6 @@ async def test_list_motor_positions(client, capsys):
         ]
     )
     assert first_motor == expected
-
-
-# Use a timezone we're not likely to be in for testing tz-aware behavior
-fake_time = dt.datetime(2022, 8, 19, 19, 10, 51, tzinfo=ZoneInfo("Asia/Taipei"))
 
 
 @time_machine.travel(fake_time, tick=True)

--- a/src/haven/tests/test_save_motor_positions.py
+++ b/src/haven/tests/test_save_motor_positions.py
@@ -235,18 +235,72 @@ position_runs = {
     ),
     # A saved motor position, but older
     "5dd9a185-d5c4-4c8b-a719-9d7beb9007dc": MapAdapter(
-        {},
+        {
+            "primary": MapAdapter(
+                {
+                    "data": DatasetAdapter.from_dataset(
+                        pd.DataFrame(
+                            {
+                                "motorC": [11250.0],
+                            }
+                        ).to_xarray()
+                    ),
+                },
+                metadata={
+                    "descriptors": {
+                        "data_keys": {
+                            "motorC": {"object_name": "motorC"},
+                        },
+                    },
+                },
+            ),
+        },
         metadata={
             "plan_name": "save_motor_position",
+            "position_name": "Another good position",
             "time": 1725897033,
-        },
+            "uid": "5dd9a185-d5c4-4c8b-a719-9d7beb9007dc",
+            "start": {
+                "plan_name": "save_motor_position",
+                "position_name": "Another good position",
+                "time": 1725897033,
+                "uid": "5dd9a185-d5c4-4c8b-a719-9d7beb9007dc",
+            },
+        },        
     ),
     # A saved motor position, but older
     "42b8c45d-e98d-4f59-9ce8-8f14134c90bd": MapAdapter(
-        {},
+                {
+            "primary": MapAdapter(
+                {
+                    "data": DatasetAdapter.from_dataset(
+                        pd.DataFrame(
+                            {
+                                "motorC": [11250.0],
+                            }
+                        ).to_xarray()
+                    ),
+                },
+                metadata={
+                    "descriptors": {
+                        "data_keys": {
+                            "motorC": {"object_name": "motorC"},
+                        },
+                    },
+                },
+            ),
+        },
         metadata={
             "plan_name": "save_motor_position",
+            "position_name": "Another good position",
             "time": 1725897233,
+            "uid": "42b8c45d-e98d-4f59-9ce8-8f14134c90bd",
+            "start": {
+                "plan_name": "save_motor_position",
+                "position_name": "Another good position",
+                "time": 17258972333,
+                "uid": "42b8c45d-e98d-4f59-9ce8-8f14134c90bd",
+            },
         },
     ),    
     # A scan that's not a saved motor position
@@ -342,20 +396,22 @@ def test_recall_motor_position(mongodb, sim_motor_registry):
     assert msg1.args[0] == -211.93
 
 
-def test_list_motor_positions(mongodb, capsys):
+async def test_list_motor_positions(client, capsys):
     # Do the listing
-    list_motor_positions(collection=mongodb.motor_positions)
+    await list_motor_positions()
     # Check stdout for printed motor positions
     captured = capsys.readouterr()
     assert len(captured.out) > 0
-    uid = str(mongodb.motor_positions.find_one({"name": "Good position A"})["_id"])
-    timestamp = "2022-08-19 19:10:51"
-    expected = (
-        f'\n\033[1mGood position A\033[0m (uid="{uid}", timestamp={timestamp})\n'
-        "┣━SLT V Upper: 510.5, offset: 0.0\n"
-        "┗━SLT V Lower: -211.93, offset: None\n"
-    )
-    assert captured.out == expected
+    first_motor = captured.out.split("\n\n")[0]
+    uid = "a9b3e0fa-eba1-43e0-a38c-c7ac76278000"
+    timestamp = "2024-09-09 10:52:13"
+    expected = "\n".join([
+        f'Good position A',
+        f'┣ uid="{uid}", timestamp={timestamp}',
+        f"┣━motorA: 12.0, offset: None",
+        f"┗━motorB: -113.25, offset: None",
+    ])
+    assert first_motor == expected
 
 
 def test_motor_position_e2e(mongodb, sim_motor_registry):


### PR DESCRIPTION
Previously, saved motor positions resided in their own database collection. This PR re-factors the save motor position support to use bluesky plans. This will mean we don't need to maintain a separate database collection.

Also uses rich to format the printed motor positions:
![image](https://github.com/user-attachments/assets/9a8f3fdf-b588-4015-a698-f4492774356e)

There's a new function ``get_motor_positions()`` which will query the database for a list of motor positions based on when they were recorded. Useful for the Firefly support. To make the Firefly support more fluid, these functions are asynchronous.

All this support only works with ophyd-async devices. This means the remaining vanilla ophyd devices will not work. Also, I think the robot support uses the ``rbv()`` function from this module. We should think about whether this still works. The tests still pass so hopefully it's not too big of a difference (or the tests are fragile).