### PR TITLE
energy positioner disables mono-ID tracking before setting energy

### DIFF
--- a/src/haven/devices/energy_positioner.py
+++ b/src/haven/devices/energy_positioner.py
@@ -118,7 +118,6 @@ class EnergyPositioner(Positioner):
         # Turn off the mono-ID tracking in the EPICS IOC since it
         # conflicts with the Haven equivalent
         was_tracking = await self.monochromator.id_tracking.get_value()
-        print(was_tracking)
         await self.monochromator.id_tracking.set(False)
         # Set the actual energy on the mono
         await super().set(value=value, wait=wait, timeout=timeout)

--- a/src/haven/devices/energy_positioner.py
+++ b/src/haven/devices/energy_positioner.py
@@ -1,6 +1,12 @@
 import logging
 
-from ophyd_async.core import HintedSignal, Signal
+from ophyd_async.core import (
+    CALCULATE_TIMEOUT,
+    AsyncStatus,
+    CalculatableTimeout,
+    HintedSignal,
+    Signal,
+)
 
 from ..positioner import Positioner
 from .monochromator import Monochromator
@@ -103,6 +109,22 @@ class EnergyPositioner(Positioner):
     def get_energy(self, values, mono: float, undulator: Signal | None = None):
         # Use just the mono value as a readback
         return values[mono]
+
+    @AsyncStatus.wrap
+    async def set(
+        self, value: float, wait=True, timeout: CalculatableTimeout = CALCULATE_TIMEOUT
+    ):
+
+        # Turn off the mono-ID tracking in the EPICS IOC since it
+        # conflicts with the Haven equivalent
+        was_tracking = await self.monochromator.id_tracking.get_value()
+        print(was_tracking)
+        await self.monochromator.id_tracking.set(False)
+        # Set the actual energy on the mono
+        await super().set(value=value, wait=wait, timeout=timeout)
+        # Restore mono-ID tracking if it was previously enabled
+        if bool(was_tracking):
+            await self.monochromator.id_tracking.set(True)
 
 
 # -----------------------------------------------------------------------------

--- a/src/haven/positioner.py
+++ b/src/haven/positioner.py
@@ -74,7 +74,13 @@ class Positioner(StandardReadable, Movable, Stoppable):
             done_event.set()
 
     @WatchableAsyncStatus.wrap
-    async def set(self, value: float, timeout: CalculatableTimeout = CALCULATE_TIMEOUT):
+    async def set(
+        self,
+        value: float,
+        wait: bool = True,
+        timeout: CalculatableTimeout = CALCULATE_TIMEOUT,
+    ):
+        assert wait, "``wait==False`` not supported."
         new_position = value
         self._set_success = True
         old_position, current_position, units, precision, velocity = (

--- a/src/haven/tests/test_energy_positioner.py
+++ b/src/haven/tests/test_energy_positioner.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from ophyd_async.core import set_mock_value
+from ophyd_async.core import get_mock_put, set_mock_value
 
 from haven.devices.energy_positioner import EnergyPositioner
 from haven.devices.xray_source import BusyStatus
@@ -15,6 +15,7 @@ async def positioner():
         undulator_prefix="S255ID:",
     )
     await positioner.connect(mock=True)
+    set_mock_value(positioner.monochromator.energy.velocity, 5000)
     return positioner
 
 
@@ -38,6 +39,24 @@ async def test_real_to_pseudo_positioner(positioner):
     # Check that the pseudo single is updated
     reading = await positioner.read()
     assert reading["energy"]["value"] == 5000.0
+
+
+async def test_disable_id_tracking(positioner):
+    energy = positioner
+    # Turn on tracking to start with
+    set_mock_value(energy.monochromator.id_tracking, 1)
+    # Set the energy
+    status = energy.set(5000)
+    # Trick the Undulator into being done
+    set_mock_value(positioner.undulator.energy.done, BusyStatus.BUSY)
+    await asyncio.sleep(0.01)  # Let the event loop run
+    set_mock_value(positioner.undulator.energy.done, BusyStatus.DONE)
+    await status
+    # Check that ID tracking was disabled
+    tracking_mock = get_mock_put(positioner.monochromator.id_tracking)
+    assert tracking_mock.call_count == 2
+    assert tracking_mock.call_args_list[0].args[0] == 0
+    assert tracking_mock.call_args_list[1].args[0] == 1
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Things to do before merging:

- [x] add tests
- [x] write docs
- [x] update iconfig_testing.toml
- [x] flake8, black, and isort
