### PR TITLE
Updated dependencies to new ophyd-async release.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -58,8 +58,7 @@ dependencies:
     - bluesky-adaptive
     - bluesky >=1.8.1
     - ophyd >=1.6.3
-    # - ophyd-async > 0.8.0a4
-    - git+https://github.com/bluesky/ophyd-async.git  # switch back to pip once a new release (0.8.0a5) is available
+    - ophyd-async >=0.8.0a5
     - apstools == 1.6.20  # Leave at 1.6.20 until this is fixed: https://github.com/BCDA-APS/apstools/issues/1022
     - pcdsdevices  # For extra signal types
     - pydm >=1.18.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: System :: Hardware",
 ]
 keywords = ["synchrotron", "xray", "bluesky"]
-dependencies = ["aioca", "aiokafka", "bluesky", "ophyd", "ophyd-async>=0.8.0a3", "databroker", "apsbss", "xraydb",
+dependencies = ["aioca", "aiokafka", "bluesky", "ophyd", "ophyd-async>=0.8.0a5", "databroker", "apsbss", "xraydb",
 	        "mergedeep", "xrayutilities", "bluesky-queueserver-api", "tomlkit",
 		"apstools", "databroker", "ophyd-registry", "caproto", "pcdsdevices",
 		"strenum", "bluesky-adaptive", "tiled[client]"]


### PR DESCRIPTION
Minimum ophyd-async version is now 0.8.0a5.

Things to do before merging:

- [x] add tests
- [x] ~~write docs~~
- [x] ~~update iconfig_testing.toml~~
- [x] ~~flake8, black, and isort~~
