### PR TITLE
Ion chamber timeout

### DIFF
--- a/src/haven/devices/ion_chamber.py
+++ b/src/haven/devices/ion_chamber.py
@@ -303,6 +303,8 @@ class IonChamber(StandardReadable, Triggerable):
         if record_dark_current:
             await self.record_dark_current()
             return
+        # Calculate expected timeout value
+        timeout = await self.default_timeout()
         # Check if we've seen this signal before
         signal = self.mcs.scaler.count
         last_status = self._trigger_statuses.get(signal.source)
@@ -310,8 +312,6 @@ class IonChamber(StandardReadable, Triggerable):
         if last_status is not None and not last_status.done:
             await last_status
             return
-        # Calculate expected timeout value
-        timeout = await self.default_timeout()
         # Nothing to wait on yet, so trigger the scaler and stash the result
         st = signal.set(True, timeout=timeout)
         self._trigger_statuses[signal.source] = st

--- a/src/haven/devices/ion_chamber.py
+++ b/src/haven/devices/ion_chamber.py
@@ -271,8 +271,23 @@ class IonChamber(StandardReadable, Triggerable):
                 # Update the labjack's input's .DESC field to match the scaler channel
                 await self.voltmeter_channel.description.set(desc)
 
-    async def default_timeout(self):
-        """Calculate the expected timeout for triggering this ion chamber."""
+    async def default_timeout(self) -> float:
+        """Calculate the expected timeout for triggering this ion chamber.
+
+        If ``self.mcs.scaler.preset_time`` is set and the first
+        (clock) channel is serving as a gate
+        (``self.mcs.scaler.channels[0].is_gate.get_value() == True``)
+        then the timeout is a little longer than the preset
+        time. Otherwise the timeout is calculated based on the longest
+        time the scaler can count for based on when the channel 0
+        clock register would fill up.
+
+        Returns
+        =======
+        timeout
+          The optimal timeout for trigger this ion chamber's scaler.
+
+        """
         aws = [
             self.mcs.scaler.channels[0].is_gate.get_value(),
             self.mcs.scaler.preset_time.get_value(),

--- a/src/haven/tests/test_ion_chamber.py
+++ b/src/haven/tests/test_ion_chamber.py
@@ -123,6 +123,7 @@ async def test_readables(ion_chamber):
 @pytest.mark.asyncio
 async def test_trigger(ion_chamber):
     await ion_chamber.connect(mock=True)
+    set_mock_value(ion_chamber.mcs.scaler.clock_frequency, 50e6)
     assert ion_chamber._trigger_statuses == {}
     # Does the same trigger twice return the same
     status1 = ion_chamber.trigger()
@@ -144,6 +145,31 @@ async def test_trigger_dark_current(ion_chamber, monkeypatch):
     status = ion_chamber.trigger(record_dark_current=True)
     await status
     assert ion_chamber.mcs.scaler.record_dark_current.trigger.called
+
+
+async def test_default_timeout_with_time(ion_chamber):
+    await ion_chamber.connect(mock=True)
+    await ion_chamber.mcs.scaler.channels[0].is_gate.set(True)
+    await ion_chamber.mcs.scaler.preset_time.set(17)
+    timeout = await ion_chamber.default_timeout()
+    assert timeout == pytest.approx(27)
+
+
+async def test_default_timeout_with_gate(ion_chamber):
+    """If another channel is gated, then use the maximum timeout.
+
+    Assume the internal register is 32-bit, then we can count for at most:
+
+      2**32 / clock_freq
+
+    """
+    clock_freq = 50e6
+    await ion_chamber.connect(mock=True)
+    await ion_chamber.mcs.scaler.channels[0].is_gate.set(False)
+    await ion_chamber.mcs.scaler.clock_frequency.set(clock_freq)
+    timeout = await ion_chamber.default_timeout()
+    buff_size = 2**32
+    assert timeout == pytest.approx(buff_size / clock_freq + 10)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR adds a proper timeout calculation to the ``IonChamber.trigger()`` method. Previously, the default timeout was used regardless of the settings on the scaler. Now, the new method ``IonChamber.default_timeout()`` is used to determine the best timeout based on the scaler configuration.

Things to do before merging:

- [x] add tests
- [x] write docs
- [x] ~~update iconfig_testing.toml~~
- [x] flake8, black, and isort
