### PR TITLE
Converted ophyd enum types to uppercase.

### DIFF
--- a/src/haven/devices/srs570.py
+++ b/src/haven/devices/srs570.py
@@ -302,27 +302,27 @@ class SRS570PreAmplifier(Device):
         LOW_DRIFT = "LOW DRIFT"
 
     class SensValue(StrictEnum):
-        _1 = "1"
-        _2 = "2"
-        _5 = "5"
-        _10 = "10"
-        _20 = "20"
-        _50 = "50"
-        _100 = "100"
-        _200 = "200"
-        _500 = "500"
+        ONE = "1"
+        TWO = "2"
+        FIVE = "5"
+        TEN = "10"
+        TWENTY = "20"
+        FIFTY = "50"
+        ONE_HUNDRED = "100"
+        TWO_HUNDRED = "200"
+        FIVE_HUNDRED = "500"
 
     class SensUnit(StrictEnum):
-        pA_V = "pA/V"
-        nA_V = "nA/V"
-        uA_V = "uA/V"
-        mA_V = "mA/V"
+        PICOAMP_PER_VOLT = "pA/V"
+        NANOAMP_PER_VOLT = "nA/V"
+        MICROAMP_PER_VOLT = "uA/V"
+        MILLIAMP_PER_VOLT = "mA/V"
 
     class OffsetUnit(StrictEnum):
-        pA = "pA"
-        nA = "nA"
-        uA = "uA"
-        mA = "mA"
+        PICOAMP = "pA"
+        NANOAMP = "nA"
+        MICROAMP = "uA"
+        MILLIAMP = "mA"
 
     def __init__(self, prefix: str, name: str = ""):
         """

--- a/src/haven/positioner.py
+++ b/src/haven/positioner.py
@@ -54,10 +54,10 @@ class Positioner(StandardReadable, Movable, Stoppable):
         self.put_complete = put_complete
         super().__init__(name=name)
 
-    def set_name(self, name: str):
+    def set_name(self, name: str, *args, **kwargs):
         super().set_name(name)
         # Readback should be named the same as its parent in read()
-        self.readback.set_name(name)
+        self.readback.set_name(name, *args, **kwargs)
 
     def watch_done(
         self, value, done_event: asyncio.Event, started_event: asyncio.Event

--- a/src/haven/tests/test_srs570.py
+++ b/src/haven/tests/test_srs570.py
@@ -112,7 +112,7 @@ gain_modes = ["LOW NOISE", "HIGH BW"]
 
 async def test_preamp_signals(preamp):
     # Check the enums
-    await preamp.sensitivity_value.set(SRS570PreAmplifier.SensValue._5)
+    await preamp.sensitivity_value.set(SRS570PreAmplifier.SensValue.FIVE)
 
 
 @pytest.mark.parametrize("gain_mode", gain_modes)


### PR DESCRIPTION
The next version of ophyd-async will enforce capitalization for attributes on enum types. Currently, these are recommended by convention, and so doing this now shouldn't cause any backwards compatibility issues.

Things to do before merging:

- [x] add tests
- ~write docs~
- ~update iconfig_testing.toml~
- [x] flake8, black, and isort
