### PR TITLE
Updated tests to use the new ``testing`` module from ophyd-async.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -59,7 +59,7 @@ dependencies:
     - bluesky-adaptive
     - bluesky >=1.8.1
     - ophyd >=1.6.3
-    - ophyd-async >=0.8.0a5
+    - ophyd-async >=0.9.0a1
     - apstools == 1.6.20  # Leave at 1.6.20 until this is fixed: https://github.com/BCDA-APS/apstools/issues/1022
     - pcdsdevices  # For extra signal types
     - pydm >=1.18.0

--- a/src/firefly/tests/test_grid_scan_window.py
+++ b/src/firefly/tests/test_grid_scan_window.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 from bluesky_queueserver_api import BPlan
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 from qtpy import QtCore
 
 from firefly.plans.grid_scan import GridScanDisplay

--- a/src/firefly/tests/test_line_scan_window.py
+++ b/src/firefly/tests/test_line_scan_window.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from bluesky_queueserver_api import BPlan
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 from qtpy import QtCore
 
 from firefly.plans.line_scan import LineScanDisplay

--- a/src/haven/tests/test_energy_positioner.py
+++ b/src/haven/tests/test_energy_positioner.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from ophyd_async.core import get_mock_put, set_mock_value
+from ophyd_async.testing import get_mock_put, set_mock_value
 
 from haven.devices.energy_positioner import EnergyPositioner
 from haven.devices.xray_source import BusyStatus

--- a/src/haven/tests/test_ion_chamber.py
+++ b/src/haven/tests/test_ion_chamber.py
@@ -4,7 +4,8 @@ from unittest.mock import AsyncMock
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from ophyd_async.core import TriggerInfo, assert_value, get_mock_put, set_mock_value
+from ophyd_async.core import TriggerInfo
+from ophyd_async.testing import assert_value, get_mock_put, set_mock_value
 
 from haven.devices.ion_chamber import IonChamber
 

--- a/src/haven/tests/test_motor.py
+++ b/src/haven/tests/test_motor.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from bluesky.protocols import Flyable
-from ophyd_async.core import get_mock_put
+from ophyd_async.testing import get_mock_put
 
 from haven.devices.motor import HavenMotor
 from haven.devices.motor import Motor as AsyncMotor

--- a/src/haven/tests/test_positioner.py
+++ b/src/haven/tests/test_positioner.py
@@ -1,8 +1,8 @@
 import asyncio
 
 import pytest
-from ophyd_async.core import get_mock_put, set_mock_value
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw, epics_signal_x
+from ophyd_async.testing import get_mock_put, set_mock_value
 
 from haven.positioner import Positioner
 

--- a/src/haven/tests/test_save_motor_positions.py
+++ b/src/haven/tests/test_save_motor_positions.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 import pandas as pd
 import pytest
 import time_machine
-from ophyd_async.core import set_mock_value
+from ophyd_async.testing import set_mock_value
 from tiled.adapters.mapping import MapAdapter
 from tiled.adapters.xarray import DatasetAdapter
 from tiled.client import Context, from_context

--- a/src/haven/tests/test_shutter.py
+++ b/src/haven/tests/test_shutter.py
@@ -1,6 +1,6 @@
 import pytest
 from ophyd.utils.errors import ReadOnlyError
-from ophyd_async.core import get_mock_put, set_mock_value
+from ophyd_async.testing import get_mock_put, set_mock_value
 
 from haven.devices.shutter import PssShutter, ShutterState
 

--- a/src/haven/tests/test_signal.py
+++ b/src/haven/tests/test_signal.py
@@ -3,9 +3,10 @@ import math
 from unittest.mock import MagicMock
 
 import pytest
-from ophyd_async.core import Device, DeviceVector, get_mock_put
+from ophyd_async.core import Device, DeviceVector
 from ophyd_async.core._signal import soft_signal_rw
 from ophyd_async.epics.core import epics_signal_rw, epics_signal_x
+from ophyd_async.testing import get_mock_put
 
 from haven.devices.signal import derived_signal_rw, derived_signal_x
 

--- a/src/haven/tests/test_srs570.py
+++ b/src/haven/tests/test_srs570.py
@@ -2,7 +2,7 @@ import asyncio
 from unittest import mock
 
 import pytest
-from ophyd_async.core import get_mock_put
+from ophyd_async.testing import get_mock_put
 
 from haven.devices.srs570 import GainSignal, SRS570PreAmplifier
 

--- a/src/haven/tests/test_xray_source.py
+++ b/src/haven/tests/test_xray_source.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from ophyd_async.core import get_mock_put, set_mock_value
+from ophyd_async.testing import get_mock_put, set_mock_value
 
 from haven.devices.xray_source import BusyStatus, PlanarUndulator
 


### PR DESCRIPTION
Recently, ophyd-async moved the mock-signal utilities to a new module ``testing``: https://github.com/bluesky/ophyd-async/pull/695

This PR updates our tests to use this new module structure. No production code was changed.

Things to do before merging:

- [x] add tests
- ~write docs~
- ~update iconfig_testing.toml~
- [x] flake8, black, and isort
