### PR TITLE
Added an error dialog for showing export errors in run browser.

### DIFF
--- a/src/firefly/controller.py
+++ b/src/firefly/controller.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from functools import partial
 from pathlib import Path
 
+import httpx
 import pydm
 import pyqtgraph as pg
 import qtawesome as qta
@@ -340,7 +341,13 @@ class FireflyController(QtCore.QObject):
         self.run_updated.connect(display.update_running_scan)
         self.run_stopped.connect(display.update_running_scan)
         # Set initial state for the run_browser
-        client = tiled_client(catalog=None)
+        try:
+            client = tiled_client(catalog=None)
+        except httpx.ConnectError as exc:
+            msg = "Could not connect to Tiled.<br /><br />"
+            msg += f"{exc.request.url}"
+            display.error_dialog.showMessage(msg, "connection error")
+            raise exc
         config = load_config()["tiled"]
         await display.setup_database(
             tiled_client=client, catalog_name=config["default_catalog"]

--- a/src/firefly/run_browser/run_browser.ui
+++ b/src/firefly/run_browser/run_browser.ui
@@ -692,7 +692,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>3</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="metadata_tab">
           <attribute name="title">


### PR DESCRIPTION
Firefly's run browser can export scans through Tiled. If Tiled fails to export a scan, the error was only present in the Firefly console. This PR adds a QErrorMessage that reports to the operator that the export failed.

Things to do before merging:

- ~add tests~
- ~write docs~
- ~update iconfig_testing.toml~
- [x] flake8, black, and isort
