### PR TITLE
Ophyd-async support for Eiger area detectors

### DIFF
--- a/docs/topic_guides/area_detectors.rst
+++ b/docs/topic_guides/area_detectors.rst
@@ -10,7 +10,7 @@ are in the :py:mod:`haven.devices.area_detector` module. Newer
 
 Currently supported detectors:
 
-- Eiger 500K (:py:class:`~haven.devices.area_detector.Eiger500K`)
+- Eiger (e.g. 500K) (:py:class:`~haven.devices.detector.eiger.EigerDetector`)
 - Lambda (:py:class:`~haven.devices.area_detector.Lambda250K`)
 - Simulated detector (:py:class:`~haven.devices.detectors.sim_detector.SimDetector`)
 - Aravis cameras (:py:class:`~haven.devices.detectors.aravis.AravisDetector`)

--- a/src/haven/devices/__init__.py
+++ b/src/haven/devices/__init__.py
@@ -1,4 +1,5 @@
 from .detectors.aravis import AravisDetector  # noqa: F401
+from .detectors.eiger import EigerDetector  # noqa: F401
 from .detectors.sim_detector import SimDetector  # noqa: F401
 from .detectors.xspress import Xspress3Detector  # noqa: F401
 from .ion_chamber import IonChamber  # noqa: F401

--- a/src/haven/devices/area_detector.py
+++ b/src/haven/devices/area_detector.py
@@ -9,7 +9,9 @@ import numpy as np
 import pandas as pd
 from apstools.devices import CamMixin_V34, SingleTrigger_V34
 from ophyd import ADComponent as ADCpt
-from ophyd import CamBase
+from ophyd import (
+    CamBase,
+)
 from ophyd import Component as Cpt
 from ophyd import DetectorBase as OphydDetectorBase
 from ophyd import (
@@ -41,7 +43,10 @@ from ophyd.areadetector.plugins import (
 )
 from ophyd.areadetector.plugins import StatsPlugin_V31 as OphydStatsPlugin_V31
 from ophyd.areadetector.plugins import StatsPlugin_V34 as OphydStatsPlugin_V34
-from ophyd.areadetector.plugins import TIFFPlugin_V31, TIFFPlugin_V34
+from ophyd.areadetector.plugins import (
+    TIFFPlugin_V31,
+    TIFFPlugin_V34,
+)
 from ophyd.flyers import FlyerInterface
 from ophyd.sim import make_fake_device
 from ophyd.status import Status, StatusBase, SubscriptionStatus

--- a/src/haven/devices/area_detector.py
+++ b/src/haven/devices/area_detector.py
@@ -9,14 +9,11 @@ import numpy as np
 import pandas as pd
 from apstools.devices import CamMixin_V34, SingleTrigger_V34
 from ophyd import ADComponent as ADCpt
-from ophyd import (
-    CamBase,
-)
+from ophyd import CamBase
 from ophyd import Component as Cpt
 from ophyd import DetectorBase as OphydDetectorBase
 from ophyd import (
     Device,
-    EigerDetectorCam,
     EpicsSignal,
     Kind,
     Lambda750kCam,
@@ -44,10 +41,7 @@ from ophyd.areadetector.plugins import (
 )
 from ophyd.areadetector.plugins import StatsPlugin_V31 as OphydStatsPlugin_V31
 from ophyd.areadetector.plugins import StatsPlugin_V34 as OphydStatsPlugin_V34
-from ophyd.areadetector.plugins import (
-    TIFFPlugin_V31,
-    TIFFPlugin_V34,
-)
+from ophyd.areadetector.plugins import TIFFPlugin_V31, TIFFPlugin_V34
 from ophyd.flyers import FlyerInterface
 from ophyd.sim import make_fake_device
 from ophyd.status import Status, StatusBase, SubscriptionStatus
@@ -58,7 +52,7 @@ from .._iconfig import load_config
 log = logging.getLogger(__name__)
 
 
-__all__ = ["Eiger500K", "Lambda250K", "SimDetector", "AsyncCamMixin"]
+__all__ = ["Lambda250K", "SimDetector", "AsyncCamMixin"]
 
 
 class WriteModes(IntEnum):
@@ -293,9 +287,6 @@ class SingleImageModeTrigger(SingleTrigger_V34):
 class SimDetectorCam_V34(CamMixin_V34, SimDetectorCam): ...
 
 
-class EigerCam(AsyncCamMixin, EigerDetectorCam): ...
-
-
 class LambdaCam(AsyncCamMixin, Lambda750kCam): ...
 
 
@@ -480,37 +471,6 @@ class Lambda250K(SingleTrigger, DetectorBase):
         "stats5",
         "hdf1",
         "tiff",
-    ]
-
-
-class Eiger500K(SingleTrigger, DetectorBase):
-    """
-    A Eiger S 500K area detector device.
-    """
-
-    cam = ADCpt(EigerCam, "cam1:")
-    image = ADCpt(ImagePlugin_V34, "image1:")
-    pva = ADCpt(PvaPlugin_V34, "Pva1:")
-    # tiff = ADCpt(TIFFPlugin, "TIFF1:", kind=Kind.normal)
-    hdf = ADCpt(HDF5FilePlugin, "HDF1:", kind=Kind.normal)
-    # roi1 = ADCpt(ROIPlugin_V34, "ROI1:", kind=Kind.config)
-    # roi2 = ADCpt(ROIPlugin_V34, "ROI2:", kind=Kind.config)
-    # roi3 = ADCpt(ROIPlugin_V34, "ROI3:", kind=Kind.config)
-    # roi4 = ADCpt(ROIPlugin_V34, "ROI4:", kind=Kind.config)
-    # stats1 = ADCpt(StatsPlugin_V34, "Stats1:", kind=Kind.normal)
-    # stats2 = ADCpt(StatsPlugin_V34, "Stats2:", kind=Kind.normal)
-    # stats3 = ADCpt(StatsPlugin_V34, "Stats3:", kind=Kind.normal)
-    # stats4 = ADCpt(StatsPlugin_V34, "Stats4:", kind=Kind.normal)
-    # stats5 = ADCpt(StatsPlugin_V34, "Stats5:", kind=Kind.normal)
-
-    _default_read_attrs = [
-        # "stats1",
-        # "stats2",
-        # "stats3",
-        # "stats4",
-        # "stats5",
-        "hdf",
-        # "tiff",
     ]
 
 

--- a/src/haven/devices/detectors/eiger.py
+++ b/src/haven/devices/detectors/eiger.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from ophyd_async.core import PathProvider, SignalR
 from ophyd_async.epics import adcore
 from ophyd_async.epics.adcore import ADBaseController, AreaDetector
+from ophyd_async.epics.adcore._utils import ADBaseDataType, convert_ad_dtype_to_np
 from ophyd_async.epics.core import epics_signal_r, epics_signal_rw_rbv
 
 from .area_detectors import default_path_provider
@@ -17,10 +18,30 @@ class EigerDriverIO(adcore.ADBaseIO):
         self.sensor_material = epics_signal_r(str, f"{prefix}SensorMaterial_RBV")
         self.sensor_thickness = epics_signal_r(float, f"{prefix}SensorThickness_RBV")
         self.dead_time = epics_signal_r(float, f"{prefix}DeadTime_RBV")
+        self.bit_depth = epics_signal_r(int, f"{prefix}BitDepthImage_RBV")
         # Detector status
         self.threshold_energy = epics_signal_rw_rbv(float, f"{prefix}ThresholdEnergy")
         self.photon_energy = epics_signal_rw_rbv(float, f"{prefix}PhotonEnergy")
         super().__init__(prefix=prefix, name=name)
+
+
+class EigerDatasetDescriber(adcore.ADBaseDatasetDescriber):
+    """The datatype cannot be reliably determined from DataType_RBV.
+
+    The Eiger always reports the data type as Int8, but this is never
+    going to be correct. Instead, the data type can be inferred from
+    the bit depth reported by the detector.
+
+    """
+
+    async def np_datatype(self) -> str:
+        bit_depth = await self._driver.bit_depth.get_value()
+        types = {
+            8: ADBaseDataType.UINT8,
+            16: ADBaseDataType.UINT16,
+            32: ADBaseDataType.UINT32,
+        }
+        return convert_ad_dtype_to_np(types[bit_depth])
 
 
 class EigerController(ADBaseController):
@@ -49,11 +70,12 @@ class EigerDetector(AreaDetector):
         # Area detector IO devices
         driver = EigerDriverIO(f"{prefix}{drv_suffix}")
         controller = EigerController(driver)
-        writer = writer_cls.with_io(
-            prefix,
+        fileio = adcore.NDFileHDFIO(f"{prefix}{fileio_suffix}")
+        writer = writer_cls(
+            fileio,
             path_provider=path_provider,
-            dataset_source=driver,
-            fileio_suffix=fileio_suffix,
+            name_provider=lambda: self.name,
+            dataset_describer=EigerDatasetDescriber(driver),
             plugins=plugins,
         )
         config_sigs = (

--- a/src/haven/devices/detectors/eiger.py
+++ b/src/haven/devices/detectors/eiger.py
@@ -1,0 +1,78 @@
+from collections.abc import Sequence
+
+from ophyd_async.core import PathProvider, SignalR
+from ophyd_async.epics import adcore
+from ophyd_async.epics.adcore import ADBaseController, AreaDetector
+from ophyd_async.epics.core import epics_signal_r, epics_signal_rw_rbv
+
+from .area_detectors import default_path_provider
+
+
+class EigerDriverIO(adcore.ADBaseIO):
+    def __init__(self, prefix, name=""):
+        # Detector information
+        self.description = epics_signal_r(str, f"{prefix}Description_RBV")
+        self.pixel_size_x = epics_signal_r(float, f"{prefix}XPixelSize_RBV")
+        self.pixel_size_y = epics_signal_r(float, f"{prefix}YPixelSize_RBV")
+        self.sensor_material = epics_signal_r(str, f"{prefix}SensorMaterial_RBV")
+        self.sensor_thickness = epics_signal_r(float, f"{prefix}SensorThickness_RBV")
+        self.dead_time = epics_signal_r(float, f"{prefix}DeadTime_RBV")
+        # Detector status
+        self.threshold_energy = epics_signal_rw_rbv(float, f"{prefix}ThresholdEnergy")
+        self.photon_energy = epics_signal_rw_rbv(float, f"{prefix}PhotonEnergy")
+        super().__init__(prefix=prefix, name=name)
+
+
+class EigerController(ADBaseController):
+    def get_deadtime(self, exposure: float | None) -> float:
+        raise NotImplementedError("Read deadtime from signal")
+
+
+class EigerDetector(AreaDetector):
+    """An Eiger area detector, e.g. Eiger 500K."""
+
+    _ophyd_labels_ = {"detectors", "area_detectors"}
+
+    def __init__(
+        self,
+        prefix: str,
+        path_provider: PathProvider | None = None,
+        drv_suffix="cam1:",
+        writer_cls: type[adcore.ADWriter] = adcore.ADHDFWriter,
+        fileio_suffix="HDF1:",
+        name: str = "",
+        config_sigs: Sequence[SignalR] = (),
+        plugins: dict[str, adcore.NDPluginBaseIO] | None = None,
+    ):
+        if path_provider is None:
+            path_provider = default_path_provider()
+        # Area detector IO devices
+        driver = EigerDriverIO(f"{prefix}{drv_suffix}")
+        controller = EigerController(driver)
+        writer = writer_cls.with_io(
+            prefix,
+            path_provider=path_provider,
+            dataset_source=driver,
+            fileio_suffix=fileio_suffix,
+            plugins=plugins,
+        )
+        config_sigs = (
+            driver.pixel_size_x,
+            driver.pixel_size_y,
+            driver.sensor_material,
+            driver.sensor_thickness,
+            driver.threshold_energy,
+            driver.photon_energy,
+            *config_sigs,
+        )
+        super().__init__(
+            controller=controller,
+            writer=writer,
+            plugins=plugins,
+            name=name,
+            config_sigs=config_sigs,
+        )
+
+    @property
+    def default_time_signal(self):
+        return self.driver.acquire_time

--- a/src/haven/devices/detectors/eiger.py
+++ b/src/haven/devices/detectors/eiger.py
@@ -98,3 +98,29 @@ class EigerDetector(AreaDetector):
     @property
     def default_time_signal(self):
         return self.driver.acquire_time
+
+
+# -----------------------------------------------------------------------------
+# :author:    Mark Wolfman
+# :email:     wolfman@anl.gov
+# :copyright: Copyright © 2025, UChicago Argonne, LLC
+#
+# Distributed under the terms of the 3-Clause BSD License
+#
+# The full license is in the file LICENSE, distributed with this software.
+#
+# DISCLAIMER
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# -----------------------------------------------------------------------------

--- a/src/haven/devices/detectors/xspress.py
+++ b/src/haven/devices/detectors/xspress.py
@@ -327,3 +327,29 @@ def ndattribute_params(
         ]
         params.extend(new_params)
     return params
+
+
+# -----------------------------------------------------------------------------
+# :author:    Mark Wolfman, Yanna Chen
+# :email:     wolfman@anl.gov
+# :copyright: Copyright © 2025, UChicago Argonne, LLC
+#
+# Distributed under the terms of the 3-Clause BSD License
+#
+# The full license is in the file LICENSE, distributed with this software.
+#
+# DISCLAIMER
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# -----------------------------------------------------------------------------

--- a/src/haven/devices/detectors/xspress.py
+++ b/src/haven/devices/detectors/xspress.py
@@ -191,7 +191,6 @@ class Xspress3Detector(AreaDetector):
                 path_provider=path_provider,
                 name_provider=lambda: self.name,
                 dataset_describer=XspressDatasetDescriber(self.driver),
-                # driver=self.driver,  # <- for DT ndattributes
                 plugins=self.plugins,
             ),
             plugins=self.plugins,

--- a/src/haven/iconfig_testing.toml
+++ b/src/haven/iconfig_testing.toml
@@ -243,8 +243,13 @@ name = "sim_detector"
 prefix = "255idSimDet:"
 
 [[ camera ]]
+# An Aravis-based area detector
 name = "lerix_mono_flag"
 prefix = "255idARV3:"
+
+[[ eiger ]]
+name = "eiger_500k"
+prefix = "255idEiger:"
 
 # What follows is the style for threaded ophyd area detectors. This is
 # deprecated and will be removed in the future.

--- a/src/haven/instrument.py
+++ b/src/haven/instrument.py
@@ -6,13 +6,12 @@ from typing import Mapping
 
 from guarneri import Instrument
 
+from haven import devices
+
 from .devices.aerotech import AerotechStage
 from .devices.aps import ApsMachine
 from .devices.area_detector import make_area_detector
 from .devices.beamline_manager import BeamlineManager
-from .devices.detectors.aravis import AravisDetector
-from .devices.detectors.sim_detector import SimDetector
-from .devices.detectors.xspress import Xspress3Detector
 from .devices.dxp import make_dxp_device
 from .devices.energy_positioner import EnergyPositioner
 from .devices.heater import CapillaryHeater
@@ -86,7 +85,8 @@ beamline = HavenInstrument(
     {
         # Ophyd-async devices
         "aerotech_stage": AerotechStage,
-        "camera": AravisDetector,
+        "camera": devices.AravisDetector,
+        "eiger": devices.EigerDetector,
         "energy": EnergyPositioner,
         "high_heat_load_mirror": HighHeatLoadMirror,
         "ion_chamber": IonChamber,
@@ -94,9 +94,9 @@ beamline = HavenInstrument(
         "motor": Motor,
         "pfcu4": PFCUFilterBank,
         "pss_shutter": PssShutter,
-        "sim_detector": SimDetector,
+        "sim_detector": devices.SimDetector,
         "table": Table,
-        "xspress3": Xspress3Detector,
+        "xspress3": devices.Xspress3Detector,
         "xy_stage": XYStage,
         # Threaded ophyd devices
         "blade_slits": BladeSlits,

--- a/src/haven/tests/test_eiger.py
+++ b/src/haven/tests/test_eiger.py
@@ -1,0 +1,85 @@
+import pytest
+
+from haven.devices.detectors.eiger import EigerDetector
+
+
+@pytest.fixture()
+async def eiger():
+    detector = EigerDetector(prefix="255idEiger:", name="eiger")
+    await detector.connect(mock=True)
+    # Registry with the simulated registry
+    return detector
+
+
+async def test_signals(eiger):
+    """Confirm the device has the right signals."""
+    # for name, sig in eiger.driver.children():
+    #     print(name.ljust(20), sig.source.split("/")[-1])
+    # Detector information
+    assert (
+        eiger.driver.description.source == "mock+ca://255idEiger:cam1:Description_RBV"
+    )
+    assert (
+        eiger.driver.pixel_size_x.source == "mock+ca://255idEiger:cam1:XPixelSize_RBV"
+    )
+    assert (
+        eiger.driver.pixel_size_y.source == "mock+ca://255idEiger:cam1:YPixelSize_RBV"
+    )
+    assert (
+        eiger.driver.sensor_material.source
+        == "mock+ca://255idEiger:cam1:SensorMaterial_RBV"
+    )
+    assert (
+        eiger.driver.sensor_thickness.source
+        == "mock+ca://255idEiger:cam1:SensorThickness_RBV"
+    )
+    assert eiger.driver.dead_time.source == "mock+ca://255idEiger:cam1:DeadTime_RBV"
+    # Detector status
+    assert (
+        eiger.driver.threshold_energy.source
+        == "mock+ca://255idEiger:cam1:ThresholdEnergy_RBV"
+    )
+    assert (
+        eiger.driver.photon_energy.source
+        == "mock+ca://255idEiger:cam1:PhotonEnergy_RBV"
+    )
+
+
+async def test_configuration(eiger):
+    """Confirm the device has the right signals."""
+    config = await eiger.read_configuration()
+    from pprint import pprint
+
+    pprint(config)
+    assert "eiger-driver-pixel_size_x" in config.keys()
+    assert "eiger-driver-pixel_size_y" in config.keys()
+    assert "eiger-driver-sensor_material" in config.keys()
+    assert "eiger-driver-sensor_thickness" in config.keys()
+    assert "eiger-driver-threshold_energy" in config.keys()
+    assert "eiger-driver-photon_energy" in config.keys()
+
+
+# -----------------------------------------------------------------------------
+# :author:    Mark Wolfman
+# :email:     wolfman@anl.gov
+# :copyright: Copyright © 2024, UChicago Argonne, LLC
+#
+# Distributed under the terms of the 3-Clause BSD License
+#
+# The full license is in the file LICENSE, distributed with this software.
+#
+# DISCLAIMER
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# -----------------------------------------------------------------------------

--- a/src/haven/tests/test_eiger.py
+++ b/src/haven/tests/test_eiger.py
@@ -1,4 +1,5 @@
 import pytest
+from ophyd_async.testing import set_mock_value
 
 from haven.devices.detectors.eiger import EigerDetector
 
@@ -48,15 +49,23 @@ async def test_signals(eiger):
 async def test_configuration(eiger):
     """Confirm the device has the right signals."""
     config = await eiger.read_configuration()
-    from pprint import pprint
-
-    pprint(config)
     assert "eiger-driver-pixel_size_x" in config.keys()
     assert "eiger-driver-pixel_size_y" in config.keys()
     assert "eiger-driver-sensor_material" in config.keys()
     assert "eiger-driver-sensor_thickness" in config.keys()
     assert "eiger-driver-threshold_energy" in config.keys()
     assert "eiger-driver-photon_energy" in config.keys()
+
+
+async def test_dtype(eiger):
+    """Our eiger detector support has a bug where the "DataType_RBV" PV
+    reports "int8" even though the detector is producing other data
+    types.
+
+    """
+    set_mock_value(eiger.driver.bit_depth, 32)
+    dtype = await eiger._writer._dataset_describer.np_datatype()
+    assert dtype == "<u4"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for (at least version 1) Eiger area detectors. Tested against the Eiger 500K.

Things to do before merging:

- [x] add tests
- [x] write docs
- [x] update iconfig_testing.toml
- [x] flake8, black, and isort
