### PR TITLE
Restored Xspress NDattributes.

### DIFF
--- a/src/haven/devices/detectors/xspress.py
+++ b/src/haven/devices/detectors/xspress.py
@@ -59,11 +59,8 @@ class XspressController(ADBaseController):
         # include
         return 0.001
 
-    async def setup_ndattributes(self, device_name: str):
-        num_elements = await self.driver.number_of_elements.get_value()
-        params = ndattribute_params(
-            device_name=device_name, elements=range(num_elements)
-        )
+    async def setup_ndattributes(self, device_name: str, elements: Sequence[int]):
+        params = ndattribute_params(device_name=device_name, elements=elements)
         xml = ndattribute_xml(params)
         await self.driver.nd_attributes_file.set(xml)
 
@@ -192,7 +189,7 @@ class Xspress3Detector(AreaDetector):
         # We need the driver to be a plugin so that NDAttributes get saved
         # Can be removed once this bug is fixed upstream:
         # https://github.com/bluesky/ophyd-async/issues/821
-        writer._plugins['camera'] = driver
+        writer._plugins["camera"] = driver
         super().__init__(
             controller=controller,
             writer=writer,
@@ -211,7 +208,9 @@ class Xspress3Detector(AreaDetector):
         self._old_xml_file, *_ = await asyncio.gather(
             self.driver.nd_attributes_file.get_value(),
             super().stage(),
-            self._controller.setup_ndattributes(device_name=self.name),
+            self._controller.setup_ndattributes(
+                device_name=self.name, elements=self.elements.keys()
+            ),
             self.driver.erase_on_start.set(False),
             self.driver.erase.trigger(),
         )

--- a/src/haven/devices/detectors/xspress.py
+++ b/src/haven/devices/detectors/xspress.py
@@ -189,6 +189,10 @@ class Xspress3Detector(AreaDetector):
             dataset_describer=XspressDatasetDescriber(driver),
             plugins=plugins,
         )
+        # We need the driver to be a plugin so that NDAttributes get saved
+        # Can be removed once this bug is fixed upstream:
+        # https://github.com/bluesky/ophyd-async/issues/821
+        writer._plugins['camera'] = driver
         super().__init__(
             controller=controller,
             writer=writer,

--- a/src/haven/tests/test_xspress.py
+++ b/src/haven/tests/test_xspress.py
@@ -105,7 +105,7 @@ async def test_ndattribute_params():
 
 
 async def test_stage_ndattributes(detector):
-    num_elem = 8
+    num_elem = 4
     num_params = 1
     set_mock_value(detector.driver.number_of_elements, num_elem)
     set_mock_value(detector.driver.nd_attributes_file, "XSP3.xml")
@@ -119,6 +119,15 @@ async def test_stage_ndattributes(detector):
     # Check that the XML file gets reset when unstaged
     await detector.unstage()
     assert xml_mock.call_args[0][0] == "XSP3.xml"
+
+
+async def test_ndattribute_set(detector):
+    await detector.stage()
+    desc = await detector._writer.open()
+    assert "vortex_me4-element0-deadtime_factor" in desc.keys()
+    assert "vortex_me4-element1-deadtime_factor" in desc.keys()
+    assert "vortex_me4-element2-deadtime_factor" in desc.keys()
+    assert "vortex_me4-element3-deadtime_factor" in desc.keys()
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Need to write a test that confirms the NDAttributes are being written properly.

Things to do before merging:

- [x] add tests
- ~write docs~
- ~update iconfig_testing.toml~
- [x] flake8, black, and isort
- [ ] Test at the beamline
