### PR TITLE
Ion chambers now have count_rate signals and new hints.

### DIFF
--- a/src/haven/tests/test_ion_chamber.py
+++ b/src/haven/tests/test_ion_chamber.py
@@ -42,10 +42,12 @@ async def test_readables(ion_chamber):
     expected_readables = [
         "I0-net_current",
         "I0-raw_current",
+        "I0-count",
+        "I0-count_rate",
+        "I0-raw_count_rate",
         "I0-voltmeter-analog_inputs-1-final_value",
         "I0-mcs-scaler-channels-0-net_count",
         "I0-mcs-scaler-channels-0-raw_count",
-        "I0-mcs-scaler-channels-2-net_count",
         "I0-mcs-scaler-channels-2-raw_count",
         "I0-mcs-scaler-elapsed_time",
     ]
@@ -53,7 +55,8 @@ async def test_readables(ion_chamber):
     assert sorted(actual_readables) == sorted(expected_readables)
     # Check signal hints
     expected_hints = [
-        "I0-net_current",
+        "I0-count",
+        "I0-count_rate",
     ]
     actual_hints = ion_chamber.hints["fields"]
     assert sorted(actual_hints) == sorted(expected_hints)


### PR DESCRIPTION
In response to a recent discussion, this PR tweaks the signals on the ion chambers.

Each ion chamber now has a new signal: `I0.count_rate` that is the same as the scaler's `net_count` signal, but corrected for the true acquire time of the scaler.

The hinted signals are also tweaked so that each ion chamber has the following hinted signals:

- "I0-count"
- "I0-count_rate"

These replace the previous hinted signal of "I0-net_current".

---

Things to do before merging:

- [x] add tests
- ~write docs~
- ~update iconfig_testing.toml~
- [x] flake8, black, and isort
