### PR TITLE
FIX: PSS shutter device should now wait properly

### DIFF
--- a/src/haven/devices/shutter.py
+++ b/src/haven/devices/shutter.py
@@ -47,7 +47,7 @@ class PssShutter(Positioner):
         # Just use convenient values for these since there's no real position
         self.velocity = soft_signal_rw(float, initial_value=0.5)
         self.units = soft_signal_rw(str, initial_value="")
-        self.precision = soft_signal_rw(int, initial_value=0)
+        self.precision = soft_signal_rw(int, initial_value=2**16)
         # Positioner signals for moving the shutter
         with self.add_children_as_readables():
             self.readback = epics_signal_r(bool, f"{prefix}BeamBlockingM.VAL")


### PR DESCRIPTION
The PSS shutter is a positioner. This means that it waits for the readback value to match the setpoint before returning control to the calling context.

Each positioner has a `precision` signal. When setting a value, the positioner considers the readback to match the setpoint when they are within `10**(-precision)` of each other.

If the precision is `0`, then the positioner will wait until the readback value is within ±1 of the setpoint. For a motor this makes sense. For the shutter, `0` and `1` are the open and closed states.

For the shutter, the precision was set to `0`, so if the shutter is open (`0`), when doing…

```python
await shutter.set(1)
```

…the shutter will check that the current position is between 0 and 2 (`1±1`), which it always will be and so the call returns immediately.

This means that setting the shutter will always return immediately, even though the shutter takes 1-2 seconds to actuate.

This PR fixes this by raising the precision to 65536. Could be any number really, but this means that the same operation will now wait until the shutter position is between 0.9999999999 and 1.000000000001 or something like that.