### PR TITLE
Removed the bluesky queueserver API from Firefly controller tests.

### DIFF
--- a/src/firefly/queue_client.py
+++ b/src/firefly/queue_client.py
@@ -229,6 +229,7 @@ class QueueClient(QObject):
 
         """
         # Report results
+        print(result)
         if result["success"] is True:
             log.debug(f"{task}: {result}")
         else:
@@ -247,6 +248,7 @@ class QueueClient(QObject):
 
         """
         new_status = await self.queue_status()
+        print(new_status)
         signals_changed = self.status.send(new_status)
         # Check individual components of the status if they've changed
         if signals_changed != {}:

--- a/src/firefly/tests/test_controller.py
+++ b/src/firefly/tests/test_controller.py
@@ -1,7 +1,6 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from bluesky_queueserver_api.zmq.aio import REManagerAPI
 from ophyd import Device
 from ophyd.sim import make_fake_device
 from ophydregistry import Registry
@@ -22,7 +21,9 @@ async def controller(qapp):
 
 @pytest.fixture()
 async def api():
-    _api = REManagerAPI()
+    _api = AsyncMock()
+    _api.status.return_value = {"success": True}
+    _api.queue_autostart.return_value = {"success": True}
     return _api
 
 


### PR DESCRIPTION
Things to do before merging:

- [x] add tests
- ~write docs~
- ~update iconfig_testing.toml~
- [x] flake8, black, and isort
